### PR TITLE
fix fastscan for AVX2

### DIFF
--- a/rabitqlib/fastscan/fastscan.hpp
+++ b/rabitqlib/fastscan/fastscan.hpp
@@ -184,7 +184,7 @@ inline void accumulate(
 
     for (size_t i = 0; i < code_length; i += 64) {
         c = _mm256_loadu_si256((__m256i*)&codes[i]);
-        lut = _mm256_loadu_si256((__m256i*)&LUT[i]);
+        lut = _mm256_loadu_si256((__m256i*)&lut[i]);
         lo = _mm256_and_si256(c, low_mask);
         hi = _mm256_and_si256(_mm256_srli_epi16(c, 4), low_mask);
 
@@ -197,7 +197,7 @@ inline void accumulate(
         accu3 = _mm256_add_epi16(accu3, _mm256_srli_epi16(res_hi, 8));
 
         c = _mm256_loadu_si256((__m256i*)&codes[i + 32]);
-        lut = _mm256_loadu_si256((__m256i*)&LUT[i + 32]);
+        lut = _mm256_loadu_si256((__m256i*)&lut[i + 32]);
         lo = _mm256_and_si256(c, low_mask);
         hi = _mm256_and_si256(_mm256_srli_epi16(c, 4), low_mask);
 

--- a/rabitqlib/fastscan/highacc_fastscan.hpp
+++ b/rabitqlib/fastscan/highacc_fastscan.hpp
@@ -23,7 +23,7 @@ inline void transfer_lut_hacc(const uint16_t* lut, size_t dim, uint8_t* hc_lut) 
 #if defined(__AVX512F__)
         constexpr size_t kRegBits = 512;
 #elif defined(__AVX2__)
-        constexpr size_t B_regi = 256;
+        constexpr size_t kRegBits = 256;
 #else
         static_assert(false, "At least requried AVX2 for using fastscan\n");
         exit(1);


### PR DESCRIPTION
### Summary
This PR introduces support for fastscan on CPUs that do not support the AVX512F instruction set, as detailed in [#14](https://github.com/VectorDB-NTU/RaBitQ-Library/issues/14).

### Details

- Fix the variable names in the AVX2 branch of the fastscan implementation.

### Testing

Compile the code for CPUs that support AVX2 but not AVX512F.

### Related Issues
[#14](https://github.com/VectorDB-NTU/RaBitQ-Library/issues/14)