### PR TITLE
Fix Quick Start in docs

### DIFF
--- a/docs/docs/quick_start.md
+++ b/docs/docs/quick_start.md
@@ -41,9 +41,10 @@ int main() {
         vector.data(), dim, bits, code.data(), delta, vl, config
     );
 
-    // reconstruct  
+    // reconstruct
+    size_t padded_dim = dim;
     float * reconstructed_data = new float [padded_dim];
-    rabitqlib::quant::reconstruct_vec(code, delta, vl, padded_dim, reconstructed_data);
+    rabitqlib::quant::reconstruct_vec(code.data(), delta, vl, padded_dim, reconstructed_data);
 
     return 0;
 }

--- a/docs/docs/quick_start.md
+++ b/docs/docs/quick_start.md
@@ -43,8 +43,8 @@ int main() {
 
     // reconstruct
     size_t padded_dim = dim;
-    float * reconstructed_data = new float [padded_dim];
-    rabitqlib::quant::reconstruct_vec(code.data(), delta, vl, padded_dim, reconstructed_data);
+    std::vector<float> reconstructed_data(padded_dim);
+    rabitqlib::quant::reconstruct_vec(code.data(), delta, vl, padded_dim, reconstructed_data.data());
 
     return 0;
 }


### PR DESCRIPTION
The variable definition `padded_dim` is missing.
The call of function `rabitqlib::quant::reconstruct_vec` should get the raw data of the vector `code`.
Use vector uniformly in code.