### PR TITLE
support load/save rotator to memory

### DIFF
--- a/include/rabitqlib/utils/fht_avx.hpp
+++ b/include/rabitqlib/utils/fht_avx.hpp
@@ -398,8 +398,8 @@ inline void helper_float_6(float *buf) {
     }
   }
 }
-void helper_float_7_recursive(float *buf, int depth);
-void helper_float_7_recursive(float *buf, int depth) {
+inline void helper_float_7_recursive(float *buf, int depth);
+inline void helper_float_7_recursive(float *buf, int depth) {
   if (depth == 7) {
     for (int j = 0; j < 128; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -592,12 +592,12 @@ void helper_float_7_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_7(float *buf);
-void helper_float_7(float *buf) {
+inline void helper_float_7(float *buf);
+inline void helper_float_7(float *buf) {
   helper_float_7_recursive(buf, 7);
 }
-void helper_float_8_recursive(float *buf, int depth);
-void helper_float_8_recursive(float *buf, int depth) {
+inline void helper_float_8_recursive(float *buf, int depth);
+inline void helper_float_8_recursive(float *buf, int depth) {
   if (depth == 6) {
     for (int j = 0; j < 64; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -807,8 +807,8 @@ void helper_float_8_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_8(float *buf);
-void helper_float_8(float *buf) {
+inline void helper_float_8(float *buf);
+inline void helper_float_8(float *buf) {
   helper_float_8_recursive(buf, 8);
 }
 inline void helper_float_9(float *buf);
@@ -1036,8 +1036,8 @@ inline void helper_float_9(float *buf) {
     }
   }
 }
-void helper_float_10_recursive(float *buf, int depth);
-void helper_float_10_recursive(float *buf, int depth) {
+inline void helper_float_10_recursive(float *buf, int depth);
+inline void helper_float_10_recursive(float *buf, int depth) {
   if (depth == 10) {
     for (int j = 0; j < 1024; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -1277,12 +1277,12 @@ void helper_float_10_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_10(float *buf);
-void helper_float_10(float *buf) {
+inline void helper_float_10(float *buf);
+inline void helper_float_10(float *buf) {
   helper_float_10_recursive(buf, 10);
 }
-void helper_float_11_recursive(float *buf, int depth);
-void helper_float_11_recursive(float *buf, int depth) {
+inline void helper_float_11_recursive(float *buf, int depth);
+inline void helper_float_11_recursive(float *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -1532,8 +1532,8 @@ void helper_float_11_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_11(float *buf);
-void helper_float_11(float *buf) {
+inline void helper_float_11(float *buf);
+inline void helper_float_11(float *buf) {
   helper_float_11_recursive(buf, 11);
 }
 inline void helper_float_12(float *buf);
@@ -1808,8 +1808,8 @@ inline void helper_float_12(float *buf) {
     }
   }
 }
-void helper_float_13_recursive(float *buf, int depth);
-void helper_float_13_recursive(float *buf, int depth) {
+inline void helper_float_13_recursive(float *buf, int depth);
+inline void helper_float_13_recursive(float *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -2089,12 +2089,12 @@ void helper_float_13_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_13(float *buf);
-void helper_float_13(float *buf) {
+inline void helper_float_13(float *buf);
+inline void helper_float_13(float *buf) {
   helper_float_13_recursive(buf, 13);
 }
-void helper_float_14_recursive(float *buf, int depth);
-void helper_float_14_recursive(float *buf, int depth) {
+inline void helper_float_14_recursive(float *buf, int depth);
+inline void helper_float_14_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -2398,12 +2398,12 @@ void helper_float_14_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_14(float *buf);
-void helper_float_14(float *buf) {
+inline void helper_float_14(float *buf);
+inline void helper_float_14(float *buf) {
   helper_float_14_recursive(buf, 14);
 }
-void helper_float_15_recursive(float *buf, int depth);
-void helper_float_15_recursive(float *buf, int depth) {
+inline void helper_float_15_recursive(float *buf, int depth);
+inline void helper_float_15_recursive(float *buf, int depth) {
   if (depth == 13) {
     for (int j = 0; j < 8192; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -2720,12 +2720,12 @@ void helper_float_15_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_15(float *buf);
-void helper_float_15(float *buf) {
+inline void helper_float_15(float *buf);
+inline void helper_float_15(float *buf) {
   helper_float_15_recursive(buf, 15);
 }
-void helper_float_16_recursive(float *buf, int depth);
-void helper_float_16_recursive(float *buf, int depth) {
+inline void helper_float_16_recursive(float *buf, int depth);
+inline void helper_float_16_recursive(float *buf, int depth) {
   if (depth == 13) {
     for (int j = 0; j < 8192; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -3070,12 +3070,12 @@ void helper_float_16_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_16(float *buf);
-void helper_float_16(float *buf) {
+inline void helper_float_16(float *buf);
+inline void helper_float_16(float *buf) {
   helper_float_16_recursive(buf, 16);
 }
-void helper_float_17_recursive(float *buf, int depth);
-void helper_float_17_recursive(float *buf, int depth) {
+inline void helper_float_17_recursive(float *buf, int depth);
+inline void helper_float_17_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -3437,12 +3437,12 @@ void helper_float_17_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_17(float *buf);
-void helper_float_17(float *buf) {
+inline void helper_float_17(float *buf);
+inline void helper_float_17(float *buf) {
   helper_float_17_recursive(buf, 17);
 }
-void helper_float_18_recursive(float *buf, int depth);
-void helper_float_18_recursive(float *buf, int depth) {
+inline void helper_float_18_recursive(float *buf, int depth);
+inline void helper_float_18_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -3832,12 +3832,12 @@ void helper_float_18_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_18(float *buf);
-void helper_float_18(float *buf) {
+inline void helper_float_18(float *buf);
+inline void helper_float_18(float *buf) {
   helper_float_18_recursive(buf, 18);
 }
-void helper_float_19_recursive(float *buf, int depth);
-void helper_float_19_recursive(float *buf, int depth) {
+inline void helper_float_19_recursive(float *buf, int depth);
+inline void helper_float_19_recursive(float *buf, int depth) {
   if (depth == 13) {
     for (int j = 0; j < 8192; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -4240,12 +4240,12 @@ void helper_float_19_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_19(float *buf);
-void helper_float_19(float *buf) {
+inline void helper_float_19(float *buf);
+inline void helper_float_19(float *buf) {
   helper_float_19_recursive(buf, 19);
 }
-void helper_float_20_recursive(float *buf, int depth);
-void helper_float_20_recursive(float *buf, int depth) {
+inline void helper_float_20_recursive(float *buf, int depth);
+inline void helper_float_20_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -4665,12 +4665,12 @@ void helper_float_20_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_20(float *buf);
-void helper_float_20(float *buf) {
+inline void helper_float_20(float *buf);
+inline void helper_float_20(float *buf) {
   helper_float_20_recursive(buf, 20);
 }
-void helper_float_21_recursive(float *buf, int depth);
-void helper_float_21_recursive(float *buf, int depth) {
+inline void helper_float_21_recursive(float *buf, int depth);
+inline void helper_float_21_recursive(float *buf, int depth) {
   if (depth == 9) {
     for (int j = 0; j < 512; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -5129,12 +5129,12 @@ void helper_float_21_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_21(float *buf);
-void helper_float_21(float *buf) {
+inline void helper_float_21(float *buf);
+inline void helper_float_21(float *buf) {
   helper_float_21_recursive(buf, 21);
 }
-void helper_float_22_recursive(float *buf, int depth);
-void helper_float_22_recursive(float *buf, int depth) {
+inline void helper_float_22_recursive(float *buf, int depth);
+inline void helper_float_22_recursive(float *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -5588,12 +5588,12 @@ void helper_float_22_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_22(float *buf);
-void helper_float_22(float *buf) {
+inline void helper_float_22(float *buf);
+inline void helper_float_22(float *buf) {
   helper_float_22_recursive(buf, 22);
 }
-void helper_float_23_recursive(float *buf, int depth);
-void helper_float_23_recursive(float *buf, int depth) {
+inline void helper_float_23_recursive(float *buf, int depth);
+inline void helper_float_23_recursive(float *buf, int depth) {
   if (depth == 9) {
     for (int j = 0; j < 512; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -6082,12 +6082,12 @@ void helper_float_23_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_23(float *buf);
-void helper_float_23(float *buf) {
+inline void helper_float_23(float *buf);
+inline void helper_float_23(float *buf) {
   helper_float_23_recursive(buf, 23);
 }
-void helper_float_24_recursive(float *buf, int depth);
-void helper_float_24_recursive(float *buf, int depth) {
+inline void helper_float_24_recursive(float *buf, int depth);
+inline void helper_float_24_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -6593,12 +6593,12 @@ void helper_float_24_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_24(float *buf);
-void helper_float_24(float *buf) {
+inline void helper_float_24(float *buf);
+inline void helper_float_24(float *buf) {
   helper_float_24_recursive(buf, 24);
 }
-void helper_float_25_recursive(float *buf, int depth);
-void helper_float_25_recursive(float *buf, int depth) {
+inline void helper_float_25_recursive(float *buf, int depth);
+inline void helper_float_25_recursive(float *buf, int depth) {
   if (depth == 7) {
     for (int j = 0; j < 128; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -7139,12 +7139,12 @@ void helper_float_25_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_25(float *buf);
-void helper_float_25(float *buf) {
+inline void helper_float_25(float *buf);
+inline void helper_float_25(float *buf) {
   helper_float_25_recursive(buf, 25);
 }
-void helper_float_26_recursive(float *buf, int depth);
-void helper_float_26_recursive(float *buf, int depth) {
+inline void helper_float_26_recursive(float *buf, int depth);
+inline void helper_float_26_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -7680,12 +7680,12 @@ void helper_float_26_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_26(float *buf);
-void helper_float_26(float *buf) {
+inline void helper_float_26(float *buf);
+inline void helper_float_26(float *buf) {
   helper_float_26_recursive(buf, 26);
 }
-void helper_float_27_recursive(float *buf, int depth);
-void helper_float_27_recursive(float *buf, int depth) {
+inline void helper_float_27_recursive(float *buf, int depth);
+inline void helper_float_27_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -8249,12 +8249,12 @@ void helper_float_27_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_27(float *buf);
-void helper_float_27(float *buf) {
+inline void helper_float_27(float *buf);
+inline void helper_float_27(float *buf) {
   helper_float_27_recursive(buf, 27);
 }
-void helper_float_28_recursive(float *buf, int depth);
-void helper_float_28_recursive(float *buf, int depth) {
+inline void helper_float_28_recursive(float *buf, int depth);
+inline void helper_float_28_recursive(float *buf, int depth) {
   if (depth == 7) {
     for (int j = 0; j < 128; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -8853,12 +8853,12 @@ void helper_float_28_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_28(float *buf);
-void helper_float_28(float *buf) {
+inline void helper_float_28(float *buf);
+inline void helper_float_28(float *buf) {
   helper_float_28_recursive(buf, 28);
 }
-void helper_float_29_recursive(float *buf, int depth);
-void helper_float_29_recursive(float *buf, int depth) {
+inline void helper_float_29_recursive(float *buf, int depth);
+inline void helper_float_29_recursive(float *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -9452,12 +9452,12 @@ void helper_float_29_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_29(float *buf);
-void helper_float_29(float *buf) {
+inline void helper_float_29(float *buf);
+inline void helper_float_29(float *buf) {
   helper_float_29_recursive(buf, 29);
 }
-void helper_float_30_recursive(float *buf, int depth);
-void helper_float_30_recursive(float *buf, int depth) {
+inline void helper_float_30_recursive(float *buf, int depth);
+inline void helper_float_30_recursive(float *buf, int depth) {
   if (depth == 6) {
     for (int j = 0; j < 64; j += 64) {
       for (int k = 0; k < 8; k += 8) {
@@ -10101,11 +10101,11 @@ void helper_float_30_recursive(float *buf, int depth) {
     return;
   }
 }
-void helper_float_30(float *buf);
-void helper_float_30(float *buf) {
+inline void helper_float_30(float *buf);
+inline void helper_float_30(float *buf) {
   helper_float_30_recursive(buf, 30);
 }
-int fht_float(float *buf, int log_n) {
+inline int fht_float(float *buf, int log_n) {
   if (log_n == 0) {
     return 0;
   }
@@ -10298,8 +10298,8 @@ inline void helper_double_3(double *buf) {
     }
   }
 }
-void helper_double_4_recursive(double *buf, int depth);
-void helper_double_4_recursive(double *buf, int depth) {
+inline void helper_double_4_recursive(double *buf, int depth);
+inline void helper_double_4_recursive(double *buf, int depth) {
   if (depth == 4) {
     for (int j = 0; j < 16; j += 16) {
       for (int k = 0; k < 4; k += 4) {
@@ -10367,8 +10367,8 @@ void helper_double_4_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_4(double *buf);
-void helper_double_4(double *buf) {
+inline void helper_double_4(double *buf);
+inline void helper_double_4(double *buf) {
   helper_double_4_recursive(buf, 4);
 }
 inline void helper_double_5(double *buf);
@@ -11588,8 +11588,8 @@ inline void helper_double_11(double *buf) {
     }
   }
 }
-void helper_double_12_recursive(double *buf, int depth);
-void helper_double_12_recursive(double *buf, int depth) {
+inline void helper_double_12_recursive(double *buf, int depth);
+inline void helper_double_12_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -11833,12 +11833,12 @@ void helper_double_12_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_12(double *buf);
-void helper_double_12(double *buf) {
+inline void helper_double_12(double *buf);
+inline void helper_double_12(double *buf) {
   helper_double_12_recursive(buf, 12);
 }
-void helper_double_13_recursive(double *buf, int depth);
-void helper_double_13_recursive(double *buf, int depth) {
+inline void helper_double_13_recursive(double *buf, int depth);
+inline void helper_double_13_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -12094,12 +12094,12 @@ void helper_double_13_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_13(double *buf);
-void helper_double_13(double *buf) {
+inline void helper_double_13(double *buf);
+inline void helper_double_13(double *buf) {
   helper_double_13_recursive(buf, 13);
 }
-void helper_double_14_recursive(double *buf, int depth);
-void helper_double_14_recursive(double *buf, int depth) {
+inline void helper_double_14_recursive(double *buf, int depth);
+inline void helper_double_14_recursive(double *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -12368,12 +12368,12 @@ void helper_double_14_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_14(double *buf);
-void helper_double_14(double *buf) {
+inline void helper_double_14(double *buf);
+inline void helper_double_14(double *buf) {
   helper_double_14_recursive(buf, 14);
 }
-void helper_double_15_recursive(double *buf, int depth);
-void helper_double_15_recursive(double *buf, int depth) {
+inline void helper_double_15_recursive(double *buf, int depth);
+inline void helper_double_15_recursive(double *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -12670,12 +12670,12 @@ void helper_double_15_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_15(double *buf);
-void helper_double_15(double *buf) {
+inline void helper_double_15(double *buf);
+inline void helper_double_15(double *buf) {
   helper_double_15_recursive(buf, 15);
 }
-void helper_double_16_recursive(double *buf, int depth);
-void helper_double_16_recursive(double *buf, int depth) {
+inline void helper_double_16_recursive(double *buf, int depth);
+inline void helper_double_16_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -12989,12 +12989,12 @@ void helper_double_16_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_16(double *buf);
-void helper_double_16(double *buf) {
+inline void helper_double_16(double *buf);
+inline void helper_double_16(double *buf) {
   helper_double_16_recursive(buf, 16);
 }
-void helper_double_17_recursive(double *buf, int depth);
-void helper_double_17_recursive(double *buf, int depth) {
+inline void helper_double_17_recursive(double *buf, int depth);
+inline void helper_double_17_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -13336,12 +13336,12 @@ void helper_double_17_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_17(double *buf);
-void helper_double_17(double *buf) {
+inline void helper_double_17(double *buf);
+inline void helper_double_17(double *buf) {
   helper_double_17_recursive(buf, 17);
 }
-void helper_double_18_recursive(double *buf, int depth);
-void helper_double_18_recursive(double *buf, int depth) {
+inline void helper_double_18_recursive(double *buf, int depth);
+inline void helper_double_18_recursive(double *buf, int depth) {
   if (depth == 12) {
     for (int j = 0; j < 4096; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -13696,12 +13696,12 @@ void helper_double_18_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_18(double *buf);
-void helper_double_18(double *buf) {
+inline void helper_double_18(double *buf);
+inline void helper_double_18(double *buf) {
   helper_double_18_recursive(buf, 18);
 }
-void helper_double_19_recursive(double *buf, int depth);
-void helper_double_19_recursive(double *buf, int depth) {
+inline void helper_double_19_recursive(double *buf, int depth);
+inline void helper_double_19_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -14073,12 +14073,12 @@ void helper_double_19_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_19(double *buf);
-void helper_double_19(double *buf) {
+inline void helper_double_19(double *buf);
+inline void helper_double_19(double *buf) {
   helper_double_19_recursive(buf, 19);
 }
-void helper_double_20_recursive(double *buf, int depth);
-void helper_double_20_recursive(double *buf, int depth) {
+inline void helper_double_20_recursive(double *buf, int depth);
+inline void helper_double_20_recursive(double *buf, int depth) {
   if (depth == 9) {
     for (int j = 0; j < 512; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -14474,12 +14474,12 @@ void helper_double_20_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_20(double *buf);
-void helper_double_20(double *buf) {
+inline void helper_double_20(double *buf);
+inline void helper_double_20(double *buf) {
   helper_double_20_recursive(buf, 20);
 }
-void helper_double_21_recursive(double *buf, int depth);
-void helper_double_21_recursive(double *buf, int depth) {
+inline void helper_double_21_recursive(double *buf, int depth);
+inline void helper_double_21_recursive(double *buf, int depth) {
   if (depth == 7) {
     for (int j = 0; j < 128; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -14896,12 +14896,12 @@ void helper_double_21_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_21(double *buf);
-void helper_double_21(double *buf) {
+inline void helper_double_21(double *buf);
+inline void helper_double_21(double *buf) {
   helper_double_21_recursive(buf, 21);
 }
-void helper_double_22_recursive(double *buf, int depth);
-void helper_double_22_recursive(double *buf, int depth) {
+inline void helper_double_22_recursive(double *buf, int depth);
+inline void helper_double_22_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -15331,12 +15331,12 @@ void helper_double_22_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_22(double *buf);
-void helper_double_22(double *buf) {
+inline void helper_double_22(double *buf);
+inline void helper_double_22(double *buf) {
   helper_double_22_recursive(buf, 22);
 }
-void helper_double_23_recursive(double *buf, int depth);
-void helper_double_23_recursive(double *buf, int depth) {
+inline void helper_double_23_recursive(double *buf, int depth);
+inline void helper_double_23_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -15794,12 +15794,12 @@ void helper_double_23_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_23(double *buf);
-void helper_double_23(double *buf) {
+inline void helper_double_23(double *buf);
+inline void helper_double_23(double *buf) {
   helper_double_23_recursive(buf, 23);
 }
-void helper_double_24_recursive(double *buf, int depth);
-void helper_double_24_recursive(double *buf, int depth) {
+inline void helper_double_24_recursive(double *buf, int depth);
+inline void helper_double_24_recursive(double *buf, int depth) {
   if (depth == 10) {
     for (int j = 0; j < 1024; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -16263,12 +16263,12 @@ void helper_double_24_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_24(double *buf);
-void helper_double_24(double *buf) {
+inline void helper_double_24(double *buf);
+inline void helper_double_24(double *buf) {
   helper_double_24_recursive(buf, 24);
 }
-void helper_double_25_recursive(double *buf, int depth);
-void helper_double_25_recursive(double *buf, int depth) {
+inline void helper_double_25_recursive(double *buf, int depth);
+inline void helper_double_25_recursive(double *buf, int depth) {
   if (depth == 8) {
     for (int j = 0; j < 256; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -16767,12 +16767,12 @@ void helper_double_25_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_25(double *buf);
-void helper_double_25(double *buf) {
+inline void helper_double_25(double *buf);
+inline void helper_double_25(double *buf) {
   helper_double_25_recursive(buf, 25);
 }
-void helper_double_26_recursive(double *buf, int depth);
-void helper_double_26_recursive(double *buf, int depth) {
+inline void helper_double_26_recursive(double *buf, int depth);
+inline void helper_double_26_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -17288,12 +17288,12 @@ void helper_double_26_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_26(double *buf);
-void helper_double_26(double *buf) {
+inline void helper_double_26(double *buf);
+inline void helper_double_26(double *buf) {
   helper_double_26_recursive(buf, 26);
 }
-void helper_double_27_recursive(double *buf, int depth);
-void helper_double_27_recursive(double *buf, int depth) {
+inline void helper_double_27_recursive(double *buf, int depth);
+inline void helper_double_27_recursive(double *buf, int depth) {
   if (depth == 9) {
     for (int j = 0; j < 512; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -17833,12 +17833,12 @@ void helper_double_27_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_27(double *buf);
-void helper_double_27(double *buf) {
+inline void helper_double_27(double *buf);
+inline void helper_double_27(double *buf) {
   helper_double_27_recursive(buf, 27);
 }
-void helper_double_28_recursive(double *buf, int depth);
-void helper_double_28_recursive(double *buf, int depth) {
+inline void helper_double_28_recursive(double *buf, int depth);
+inline void helper_double_28_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -18384,12 +18384,12 @@ void helper_double_28_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_28(double *buf);
-void helper_double_28(double *buf) {
+inline void helper_double_28(double *buf);
+inline void helper_double_28(double *buf) {
   helper_double_28_recursive(buf, 28);
 }
-void helper_double_29_recursive(double *buf, int depth);
-void helper_double_29_recursive(double *buf, int depth) {
+inline void helper_double_29_recursive(double *buf, int depth);
+inline void helper_double_29_recursive(double *buf, int depth) {
   if (depth == 11) {
     for (int j = 0; j < 2048; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -18963,12 +18963,12 @@ void helper_double_29_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_29(double *buf);
-void helper_double_29(double *buf) {
+inline void helper_double_29(double *buf);
+inline void helper_double_29(double *buf) {
   helper_double_29_recursive(buf, 29);
 }
-void helper_double_30_recursive(double *buf, int depth);
-void helper_double_30_recursive(double *buf, int depth) {
+inline void helper_double_30_recursive(double *buf, int depth);
+inline void helper_double_30_recursive(double *buf, int depth) {
   if (depth == 9) {
     for (int j = 0; j < 512; j += 32) {
       for (int k = 0; k < 4; k += 4) {
@@ -19566,11 +19566,11 @@ void helper_double_30_recursive(double *buf, int depth) {
     return;
   }
 }
-void helper_double_30(double *buf);
-void helper_double_30(double *buf) {
+inline void helper_double_30(double *buf);
+inline void helper_double_30(double *buf) {
   helper_double_30_recursive(buf, 30);
 }
-int fht_double(double *buf, int log_n) {
+inline int fht_double(double *buf, int log_n) {
   if (log_n == 0) {
     return 0;
   }

--- a/include/rabitqlib/utils/rotator.hpp
+++ b/include/rabitqlib/utils/rotator.hpp
@@ -32,6 +32,10 @@ class Rotator {
     virtual void rotate(const T* src, T* dst) const = 0;
     virtual void load(std::ifstream&) = 0;
     virtual void save(std::ofstream&) const = 0;
+    // Buffer I/O
+    virtual void load(const char *data) = 0;
+    virtual void save(char *data) const = 0; // dump to buffer
+    virtual size_t dump_bytes() const = 0;
     [[nodiscard]] size_t size() const { return this->padded_dim_; }
 };
 
@@ -88,6 +92,18 @@ class MatrixRotator : public Rotator<T> {
             (sizeof(float) * this->dim_ * this->padded_dim_)
         );
     }
+
+    void load(const char *data) override {
+        std::memcpy(rand_mat_.data(), data, sizeof(float) * this->dim_ * this->padded_dim_);
+    }
+
+    void save(char *data) const override {
+        std::memcpy(data, rand_mat_.data(), sizeof(float) * this->dim_ * this->padded_dim_);
+    }
+
+    size_t dump_bytes() const override {
+        return sizeof(float) * this->dim_ * this->padded_dim_;
+  }
 
     void rotate(const T* vec, T* rotated_vec) const override {
         ConstRowMajorMatrixMap<T> v(vec, 1, this->dim_);
@@ -242,6 +258,18 @@ class FhtKacRotator : public Rotator<float> {
             reinterpret_cast<const char*>(flip_.data()),
             static_cast<long>(sizeof(uint8_t) * flip_.size())
         );
+    }
+
+    void load(const char *data) override {
+        std::memcpy(flip_.data(), data, sizeof(uint8_t) * flip_.size());
+    }
+
+    void save(char *data) const override {
+        std::memcpy(data, flip_.data(), sizeof(uint8_t) * flip_.size());
+    }
+
+    size_t dump_bytes() const override {
+        return sizeof(uint8_t) * flip_.size();
     }
 
     FhtKacRotator& operator=(const FhtKacRotator& other) {


### PR DESCRIPTION
We are trying to integrate Rabitq-Library into https://github.com/alibaba/zvec, and need to serialize/deserialize rotator to our customized storage.