### PR TITLE
Fix memory out-of-bounds access when ex_bits is 0 in HNSW search

### DIFF
--- a/include/rabitqlib/index/hnsw/hnsw.hpp
+++ b/include/rabitqlib/index/hnsw/hnsw.hpp
@@ -1197,7 +1197,11 @@ void HierarchicalNSW::searchBaseLayerST_AdaptiveRerankOpt(
     float distk = 1e10;
 
     EstimateRecord start_estimate_record;
-    get_full_est(q_to_centroids, query_wrapper, ep_id, start_estimate_record);
+    if (ex_bits_ == 0) {
+        get_bin_est(q_to_centroids, query_wrapper, ep_id, start_estimate_record);
+    } else {
+        get_full_est(q_to_centroids, query_wrapper, ep_id, start_estimate_record);
+    }
     float est_dist = start_estimate_record.est_dist;
     float low_dist = start_estimate_record.low_dist;
 


### PR DESCRIPTION
## Description

This PR fixes a memory out-of-bounds access bug in the HNSW search functionality.

## Problem

When `ex_bits_` is 0, the `get_full_est` function accesses non-existent `ex_data`, causing out-of-bounds memory access.

## Solution

Added a check before calling `get_full_est` in `searchBaseLayerST_AdaptiveRerankOpt`. When `ex_bits_` is 0, we use `get_bin_est` instead, which is the correct behavior since there is no additional refinement data available.

## Changes

- Modified `searchBaseLayerST_AdaptiveRerankOpt` to check `ex_bits_` before calling `get_full_est`

## Testing

The fix has been tested locally and resolves the issue without introducing performance overhead in the common case (ex_bits > 0).