### PR TITLE
add turbopuffer in users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The RaBitQ algorithm has been implemented in many real-world systems in industry
 - [CockroachDB](https://github.com/cockroachdb/cockroach) - CSPANN + RaBitQ (Golang)
 - [ElasticSearch](https://github.com/elastic/elasticsearch) - HNSW + RaBitQ (Java - the algorithm is adopted with some minor modifications and renamed as "BBQ")
 - [Lucene](https://github.com/apache/lucene) - HNSW + RaBitQ (Java - the algorithm is adopted with some minor modifications and renamed as "BBQ")
+- [turbopuffer](https://turbopuffer.com/blog/ann-v3#:~:text=ANN%20v3%20employs%20the%20RaBitQ) -  SPFresh + RaBitQ
 
 ## Acknowledgement
 


### PR DESCRIPTION
👋 folks, turbopuffer uses RaBitQ (this is where I learned about your library - congrats I hope it gets the recognition it deserves by the wide public). They don't have open-source but it's a very popular vendor in embedding search and the CEO is very public on using your library, so I think it still deserves being put in the readme?