### PR TITLE
Refactor query to support transposed query bins 

### DIFF
--- a/include/rabitqlib/index/estimator.hpp
+++ b/include/rabitqlib/index/estimator.hpp
@@ -175,7 +175,7 @@ inline void split_single_estdist(
 
     ip_x0_qr = warmup_ip_x0_q<SplitSingleQuery<float>::kNumBits>(
         cur_bin.bin_code(),
-        q_obj.query_bin(),
+        q_obj.transposed_query_bin(),
         q_obj.delta(),
         q_obj.vl(),
         padded_dim,

--- a/include/rabitqlib/index/query.hpp
+++ b/include/rabitqlib/index/query.hpp
@@ -114,6 +114,7 @@ class SplitSingleQuery {
    private:
     const T* rotated_query_;
     std::vector<uint64_t> QueryBin_;
+    std::vector<uint64_t> TransposedQueryBin_;
     T G_add_;
     T G_k1xSumq_;
     T G_kbxSumq_;
@@ -121,6 +122,17 @@ class SplitSingleQuery {
     T delta_;
     T vl_;
     MetricType metric_type_ = METRIC_L2;
+
+    void transpose_query_bin(size_t num_blk, size_t b_query) {
+        TransposedQueryBin_.resize(num_blk * b_query);
+
+        for (size_t i = 0; i < num_blk; ++i) {
+            for (size_t j = 0; j < b_query; ++j) {
+                TransposedQueryBin_[j * num_blk + i] =
+                    QueryBin_[i * b_query + j];
+            }
+        }
+    }
 
    public:
     static constexpr size_t kNumBits = 4;
@@ -153,9 +165,14 @@ class SplitSingleQuery {
         rabitqlib::new_transpose_bin(
             quant_query.data(), QueryBin_.data(), padded_dim, kNumBits
         );
+
+        size_t num_blk = padded_dim / 64;
+        transpose_query_bin(num_blk, kNumBits);
     }
 
     [[nodiscard]] const uint64_t* query_bin() const { return QueryBin_.data(); }
+
+    [[nodiscard]] const uint64_t* transposed_query_bin() const { return TransposedQueryBin_.data(); }
 
     [[nodiscard]] const T* rotated_query() const { return rotated_query_; }
 

--- a/include/rabitqlib/utils/warmup_space.hpp
+++ b/include/rabitqlib/utils/warmup_space.hpp
@@ -37,8 +37,8 @@ inline __m256i popcount_avx2(__m256i v) {
 template <uint32_t b_query>
 inline float warmup_ip_x0_q(
     const uint64_t* data,   // pointer to data blocks (each 64 bits)
-    const uint64_t* query,  // pointer to query words (each 64 bits), arranged so that for
-                            // each data block the corresponding b_query query words follow
+    const uint64_t* query,  // pointer to transposed query words (each 64 bits), arranged so that 
+                            // for each data block the corresponding b_query query words follow
     float delta,
     float vl,
     size_t padded_dim,
@@ -68,23 +68,10 @@ inline float warmup_ip_x0_q(
         __m512i popcnt_x_vec = _mm512_popcnt_epi64(x_vec);
         ppc_vec = _mm512_add_epi64(ppc_vec, popcnt_x_vec);
 
-        // For accumulating the weighted popcounts per block.
-        __m512i block_ip = _mm512_setzero_si512();
-
         // Process each query component (b_query is a compile-time constant, and is small).
         for (uint32_t j = 0; j < b_query; j++) {
-            // We need to gather from query array the j-th query for each of the eight
-            // blocks. For block (i + k) the index is: ( (i + k) * b_query + j ). We
-            // construct an index vector of eight 64-bit indices.
-            uint64_t indices[vec_width];
-            for (size_t k = 0; k < vec_width; k++) {
-                indices[k] = ((i + k) * b_query + j);
-            }
-            // Load indices from memory.
-            __m512i index_vec = _mm512_loadu_si512(indices);
-            // Gather 8 query words with a scale of 8 (since query is an array of 64-bit
-            // integers).
-            __m512i q_vec = _mm512_i64gather_epi64(index_vec, query, 8);
+            // the query words are transposed, thus can be loaded with a single load
+            __m512i q_vec = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(query + j * num_blk + i));
 
             // Compute bitwise AND of data blocks and corresponding query words.
             __m512i and_vec = _mm512_and_si512(x_vec, q_vec);
@@ -92,34 +79,23 @@ inline float warmup_ip_x0_q(
             __m512i popcnt_and = _mm512_popcnt_epi64(and_vec);
 
             // Multiply by the weighting factor (1 << j) for this query position.
-            const uint64_t shift = 1ULL << j;
-            __m512i shift_vec = _mm512_set1_epi64(shift);
-            __m512i weighted = _mm512_mullo_epi64(popcnt_and, shift_vec);
+            __m512i weighted = _mm512_slli_epi64(popcnt_and, j);
 
             // Accumulate weighted popcounts for these blocks.
-            block_ip = _mm512_add_epi64(block_ip, weighted);
+            ip_vec = _mm512_add_epi64(ip_vec, weighted);
         }
-        // Add the block's query-weighted popcount to the overall ip vector.
-        ip_vec = _mm512_add_epi64(ip_vec, block_ip);
     }
 
     // Horizontally reduce the vector accumulators.
-    uint64_t ip_arr[vec_width];
-    uint64_t ppc_arr[vec_width];
-    _mm512_storeu_si512(reinterpret_cast<__m512i*>(ip_arr), ip_vec);
-    _mm512_storeu_si512(reinterpret_cast<__m512i*>(ppc_arr), ppc_vec);
-
-    for (size_t k = 0; k < vec_width; k++) {
-        ip_scalar += ip_arr[k];
-        ppc_scalar += ppc_arr[k];
-    }
+    ip_scalar  += _mm512_reduce_add_epi64(ip_vec);
+    ppc_scalar += _mm512_reduce_add_epi64(ppc_vec);
 
     // Process remaining blocks that did not fit in the vectorized loop.
     for (size_t i = vec_end; i < num_blk; i++) {
         const uint64_t x = data[i];
         ppc_scalar += __builtin_popcountll(x);
         for (uint32_t j = 0; j < b_query; j++) {
-            ip_scalar += __builtin_popcountll(x & query[i * b_query + j]) << j;
+            ip_scalar += __builtin_popcountll(x & query[j * num_blk + i]) << j;
         }
     }
 
@@ -145,20 +121,9 @@ inline float warmup_ip_x0_q(
 
         // Process each query component (b_query is a compile-time constant, and is small).
         for (uint32_t j = 0; j < b_query; j++) {
-            // Calculate Gather Indices: [idx, idx+b, idx+2b, idx+3b]
-            // Base index for this batch: i * b_query + j
-            long long base_idx = i * b_query + j;
-            
-            // Offsets for the 4 lanes: 0, b, 2b, 3b
-            __m256i index_vec = _mm256_setr_epi64x(
-                base_idx, 
-                base_idx + b_query, 
-                base_idx + 2 * b_query, 
-                base_idx + 3 * b_query
-            );
 
             // Gather query data: query[idx]
-            __m256i q_vec = _mm256_i64gather_epi64((const long long*)query, index_vec, 8);
+            __m256i q_vec = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query + j * num_blk + i));
 
             // Compute bitwise AND of data blocks and corresponding query words.
             __m256i and_vec = _mm256_and_si256(x_vec, q_vec);
@@ -173,24 +138,22 @@ inline float warmup_ip_x0_q(
         }
     }
 
+    auto mm256_reduce_add_epi64 = [](__m256i v) {
+        __m128i low = _mm256_castsi256_si128(v);
+        __m128i high = _mm256_extracti128_si256(v, 1);
+        __m128i sum = _mm_add_epi64(low, high);
+        return _mm_extract_epi64(sum, 0) + _mm_extract_epi64(sum, 1);
+    };
     // Horizontally reduce the vector accumulators.
-    uint64_t ip_arr[vec_width];
-    uint64_t ppc_arr[vec_width];
-    
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ppc_arr), ppc_vec);
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ip_arr), ip_vec);
-
-    for (size_t k = 0; k < vec_width; k++) {
-        ppc_scalar += ppc_arr[k];
-        ip_scalar += ip_arr[k];
-    }
+    ppc_scalar += mm256_reduce_add_epi64(ppc_vec);
+    ip_scalar += mm256_reduce_add_epi64(ip_vec);
 
     // Process remaining blocks that did not fit in the vectorized loop.
     for (size_t i = vec_end; i < num_blk; i++) {
         const uint64_t x = data[i];
         ppc_scalar += __builtin_popcountll(x);
         for (uint32_t j = 0; j < b_query; j++) {
-            ip_scalar += __builtin_popcountll(x & query[i * b_query + j]) << j;
+            ip_scalar += __builtin_popcountll(x & query[j * num_blk + i]) << j;
         }
     }
 


### PR DESCRIPTION
This PR adds a new field `transposed_query_bin` in `SplitSingleQuery` to eliminate the need to use gather instruction in `warmup_iq_x0_q`

## Intuiton

### Query structure before this PR
<img width="727" height="259" alt="image" src="https://github.com/user-attachments/assets/79821074-5d49-4af8-83f1-2f62fd9a64a4" />

<br>

To process N blocks in one SIMD lane, all` query[i * b_query + j]` for `j=1` must be loaded. These addresses are strided (not adjacent), so the CPU issues a gather multiple cache-line fetches with index arithmetic, much slower than a single contiguous vector load.

### Query structure after this PR

<img width="649" height="290" alt="image" src="https://github.com/user-attachments/assets/1e029a7c-258b-4ca3-92d4-29393d832741" />
<br>

Feature | Before (Row-Major) | After (Transposed)
-- | -- | --
Data Access | Strided: Accessing bits across rows requires non-contiguous memory jumps. | Contiguous: All block values for a specific bit-plane are stored sequentially.
Indexing | `query[i * b_query + j]` | `query_T[j * num_blk + i]`
Mechanism | Gather: Requires  separate loads or a "gather" instruction, which is slower. | Single Vector Load: A single SIMD instruction can load the entire bit-plane row into a register.
Processing | Requires a scalar loop, limiting parallel efficiency. | Achieves full SIMD throughput, maximizing CPU utilization.



## Result

Benchmark result for gist dataset with bits = 9, M = 32, k = 10, threads = 1

EF | QPS (Before) | QPS (After) | QPS Δ% | Recall (Before) | Recall (After) | Recall Δ%
-- | -- | -- | -- | -- | -- | --
80 | 1631.67 | 2480.81 | +52.04% | 0.8481 | 0.8484 | +0.04%
120 | 1299.51 | 1955.04 | +50.44% | 0.8907 | 0.8913 | +0.07%
200 | 1087.84 | 1377.00 | +26.58% | 0.9305 | 0.9299 | -0.06%
400 | 644.067 | 806.387 | +25.20% | 0.9615 | 0.9618 | +0.03%
600 | 466.142 | 580.440 | +24.52% | 0.9735 | 0.9731 | -0.04%
800 | 359.839 | 454.578 | +26.33% | 0.9780 | 0.9779 | -0.01%
1000 | 301.240 | 370.322 | +22.93% | 0.9802 | 0.9802 | 0.00%
1500 | 213.317 | 261.335 | +22.51% | 0.9829 | 0.9828 | -0.01%
2000 | 165.024 | 199.727 | +21.03% | 0.9846 | 0.9846 | 0.00%

Key takeaways:

- QPS improved significantly across all EF values, ranging from +21% to +52%, with the largest gains at lower EF values (80–120).
- Recall is virtually unchanged - differences are within ±0.07%, meaning the modification boosted throughput without sacrificing accuracy.