### PR TITLE
Optimize memory prefetching in HierarchicalNSW

### DIFF
--- a/include/rabitqlib/index/hnsw/hnsw.hpp
+++ b/include/rabitqlib/index/hnsw/hnsw.hpp
@@ -1209,57 +1209,56 @@ void HierarchicalNSW::searchBaseLayerST_AdaptiveRerankOpt(
 
     vl->set(ep_id);
 
+    const size_t prefetch_size = (((padded_dim_ / 8) + 63) / 64) + 1;
+    const size_t prefetch_lookahead = 4;  // Number of neighbors to prefetch in advance.
+
     while (candidate_set.has_next()) {
         // Step 1 - get the next node to explore.
         PID current_node_id = candidate_set.pop();
         int* data = (int*)get_linklist0(current_node_id);
         size_t size = get_list_count((PID*)data);
 
-        rabitqlib::memory::mem_prefetch_l1(get_bindata_by_internalid(*(data + 1)), 2);
+        for (size_t p = 0; p < prefetch_lookahead; ++p) {
+            rabitqlib::memory::mem_prefetch_l1(get_bindata_by_internalid(*(data + 1 + p)), prefetch_size);
+        }
         // Iterate over neighbors. (List starts at index 1.)
         for (size_t j = 1; j <= size; j++) {
             int candidate_id = *(data + j);
 
-            rabitqlib::memory::mem_prefetch_l1(
-                get_bindata_by_internalid(*(data + j + 1)), 2
-            );
-
-            if (!vl->get(candidate_id)) {
-                vl->set(candidate_id);
-                EstimateRecord candest;
-                get_bin_est(q_to_centroids, query_wrapper, candidate_id, candest);
-
-                if (ex_bits_ > 0) {
-                    // Check preliminary score against current worst full estimate.
-                    bool flag_update_KNNs =
-                        boundedKNN.size() < TOPK || candest.low_dist < distk;
-
-                    if (flag_update_KNNs) {
-                        // Compute the full estimate if promising.
-                        get_full_est(q_to_centroids, query_wrapper, candidate_id, candest);
-                        Candidate cand{
-                            ResultRecord(candest.est_dist, candest.low_dist),
-                            static_cast<PID>(candidate_id)
-                        };
-                        boundedKNN.insert(cand);
-                        distk = boundedKNN.worst().record.est_dist;
-                    }
-                } else {
-                    Candidate cand{
-                        ResultRecord(candest.est_dist, candest.low_dist),
-                        static_cast<PID>(candidate_id)
-                    };
-                    boundedKNN.insert(cand);
-                }
-
-                if (!candidate_set.is_full(candest.est_dist)) {
-                    candidate_set.insert(candidate_id, candest.est_dist);
-                }
-
-                rabitqlib::memory::mem_prefetch_l2(
-                    (char*)get_linklist0(candidate_set.next_id()), 2
-                );
+            if (j + prefetch_lookahead <= size) {
+                rabitqlib::memory::mem_prefetch_l1(get_bindata_by_internalid(*(data + j + prefetch_lookahead)), prefetch_size);
             }
+
+            if(vl->get(candidate_id)) {
+                continue;
+            }
+            vl->set(candidate_id);
+
+            EstimateRecord candest;
+            get_bin_est(q_to_centroids, query_wrapper, candidate_id, candest);
+
+            bool flag_update_KNNs = boundedKNN.size() < TOPK || candest.low_dist < distk;
+
+            if (flag_update_KNNs) {
+                // Compute the full estimate if promising.
+                if (ex_bits_ > 0) {
+                    get_full_est(q_to_centroids, query_wrapper, candidate_id, candest);
+                }
+                Candidate cand{
+                    ResultRecord(candest.est_dist, candest.low_dist),
+                    static_cast<PID>(candidate_id)
+                };
+                boundedKNN.insert(cand);
+                distk = boundedKNN.worst().record.est_dist;
+            }
+
+            if (!candidate_set.is_full(candest.est_dist)) {
+                candidate_set.insert(candidate_id, candest.est_dist);
+            }
+
+            rabitqlib::memory::mem_prefetch_l2(
+                (char*)get_linklist0(candidate_set.next_id()), 2
+            );
         }
     }
 


### PR DESCRIPTION
## Description
This PR changes how prefetch works and some minor code restructure. 

### Problem with current prefetch structure
<img width="875" height="133" alt="image" src="https://github.com/user-attachments/assets/edd6f81e-84ab-4d20-bb07-6a54d58024da" />
The data is not aligned to 64 bytes. For gist the data size for 1bit code is 960/8=120 byte. Each cache line is 64 bytes size. So, it takes 3 cache line as shown in the image. And for sift it will take 2. So, we need dynamic prefetch size. Also, using a prefetch lookahead of 4 allows the memory to hide the bandwidth latency.

### Results
Benchmark results for k = 10, M = 32 for gist, sift and cohere10m datasets,

#### GIST

EF | Original QPS | Modified QPS | Recall | QPS Improvement | QPS Improvement %
-- | -- | -- | -- | -- | --
80 | 2649.42 | 3419.43 | 0.8490 | +770.01 | +29.06%
120 | 2061.04 | 2746.68 | 0.8888 | +685.64 | +33.27%
200 | 1455.50 | 1979.82 | 0.9286 | +524.32 | +36.02%
400 | 846.439 | 1177.32 | 0.9601 | +330.88 | +39.09%
600 | 608.76 | 841.744 | 0.9717 | +232.98 | +38.27%
800 | 471.759 | 644.411 | 0.9774 | +172.65 | +36.60%
1000 | 385.906 | 517.075 | 0.9794 | +131.17 | +33.99%
1500 | 271.938 | 360.214 | 0.9824 | +88.28 | +32.46%
2000 | 207.451 | 267.375 | 0.9841 | +59.92 | +28.88%


#### SIFT

EF | Original QPS | Modified QPS | Recall | QPS Improvement | QPS Improvement %
-- | -- | -- | -- | -- | --
80 | 6600.52 | 7482.58 | 0.96931 | +882.06 | +13.36%
120 | 4751.02 | 5385.33 | 0.97572 | +634.31 | +13.35%
200 | 3068.70 | 3508.07 | 0.97873 | +439.37 | +14.32%
400 | 1634.76 | 1873.80 | 0.9802 | +239.04 | +14.62%
600 | 1113.55 | 1256.09 | 0.98042 | +142.54 | +12.80%
800 | 844.003 | 934.966 | 0.98055 | +90.96 | +10.78%
1000 | 674.261 | 738.257 | 0.98058 | +63.996 | +9.49%
1500 | 462.115 | 493.946 | 0.98059 | +31.831 | +6.89%
2000 | 344.600 | 361.813 | 0.98062 | +17.213 | +4.99%

#### COHERE10M
EF | Original QPS | Modified QPS | Recall | QPS Improvement | QPS Improvement %
-- | -- | -- | -- | -- | --
80 | 2852.91 | 3293.15 | 0.9433 | +440.24 | +15.43%
120 | 2240.69 | 2702.24 | 0.9541 | +461.55 | +20.60%
200 | 1522.30 | 1993.46 | 0.9665 | +471.16 | +30.95%
400 | 861.767 | 1168.24 | 0.9739 | +306.47 | +35.57%
600 | 595.525 | 807.243 | 0.9768 | +211.72 | +35.55%
800 | 452.516 | 611.897 | 0.9790 | +159.38 | +35.22%
1000 | 363.006 | 488.670 | 0.9806 | +125.66 | +34.62%
1500 | 241.294 | 321.223 | 0.9835 | +79.929 | +33.13%
2000 | 180.496 | 236.504 | 0.9841 | +56.008 | +31.03%


> SIFT has a dimension of 120 and the previous prefetch size and the currently calculated prefetch size are 2 ie  same, thus having a lesser amount of improvement