### PR TITLE
Optimize 1-bit estimator tail path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,9 @@
 
 
 .cache/
-.vscode/
 bin/
 build/
 data/
-results/
 
 *.pyc
 .clang-*

--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,11 @@
 
 
 .cache/
+.vscode/
 bin/
 build/
 data/
+results/
 
 *.pyc
 .clang-*

--- a/example.sh
+++ b/example.sh
@@ -1,28 +1,101 @@
-# compiling 
-mkdir build bin 
-cd build 
-cmake ..
-make 
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Download the dataset
-wget -P ./data/gist ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz
-tar -xzvf ./data/gist/gist.tar.gz -C ./data/gist
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="${DATA_DIR:-${ROOT_DIR}/data/gist}"
+LOG_DIR="${LOG_DIR:-${ROOT_DIR}/results/gist_example}"
+BUILD_JOBS="${BUILD_JOBS:-$(nproc)}"
 
-# indexing and querying for symqg
-./bin/symqg_indexing ./data/gist/gist_base.fvecs 32 400 ./data/gist/symqg_32.index
+BASE="${DATA_DIR}/gist_base.fvecs"
+QUERY="${DATA_DIR}/gist_query.fvecs"
+GT="${DATA_DIR}/gist_groundtruth.ivecs"
 
-./bin/symqg_querying ./data/gist/symqg_32.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs
+mkdir -p "${ROOT_DIR}/bin" "${DATA_DIR}" "${LOG_DIR}"
+cd "${ROOT_DIR}"
 
-# indexing and querying for RabitQ+ with ivf, please refer to python/ivf.py for more information about clustering
-python ./python/ivf.py ./data/gist/gist_base.fvecs 4096 ./data/gist/gist_centroids_4096.fvecs ./data/gist/gist_clusterids_4096.ivecs
+run_and_log() {
+    local name="$1"
+    shift
+    local log_file="${LOG_DIR}/${name}.log"
 
-./bin/ivf_rabitq_indexing ./data/gist/gist_base.fvecs ./data/gist/gist_centroids_4096.fvecs ./data/gist/gist_clusterids_4096.ivecs 3 ./data/gist/ivf_4096_3.index
+    echo
+    echo "===== ${name} ====="
+    "$@" 2>&1 | tee "${log_file}"
+}
 
-./bin/ivf_rabitq_querying ./data/gist/ivf_4096_3.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs
+print_recall_summary() {
+    local name="$1"
+    local log_file="${LOG_DIR}/${name}.log"
 
-# indexing and querying for RabitQ+ with hnsw, do clustering first
-python ./python/ivf.py ./data/gist/gist_base.fvecs 16 ./data/gist/gist_centroids_16.fvecs ./data/gist/gist_clusterids_16.ivecs
+    echo
+    echo "----- ${name} summary -----"
+    awk '
+        BEGIN { IGNORECASE = 1 }
+        /^[[:space:]]*(EF|nprobe)[[:space:]]/ {
+            in_table = 1
+            next
+        }
+        in_table && NF >= 3 && $1 ~ /^[0-9]+$/ {
+            last = $0
+            if (best_line == "" || ($3 + 0) > best_recall) {
+                best_recall = $3 + 0
+                best_line = $0
+            }
+        }
+        END {
+            if (best_line != "") {
+                print "best_recall_line: " best_line
+                print "last_line:        " last
+            } else {
+                print "No recall table found. Please inspect " FILENAME
+            }
+        }
+    ' "${log_file}"
+}
 
-./bin/hnsw_rabitq_indexing ./data/gist/gist_base.fvecs ./data/gist/gist_centroids_16.fvecs ./data/gist/gist_clusterids_16.ivecs 16 200 5 ./data/gist/hnsw_5.index
+echo "===== build ====="
+cmake -S "${ROOT_DIR}" -B "${ROOT_DIR}/build"
+cmake --build "${ROOT_DIR}/build" -j "${BUILD_JOBS}"
 
-./bin/hnsw_rabitq_querying ./data/gist/hnsw_5.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs
+if [[ ! -f "${BASE}" || ! -f "${QUERY}" || ! -f "${GT}" ]]; then
+    echo
+    echo "===== download gist ====="
+    if [[ ! -f "${DATA_DIR}/gist.tar.gz" ]]; then
+        wget -P "${DATA_DIR}" ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz
+    fi
+    tar -xzvf "${DATA_DIR}/gist.tar.gz" -C "${DATA_DIR}"
+fi
+
+echo
+echo "Logs will be written to ${LOG_DIR}"
+
+run_and_log symqg_indexing \
+    "${ROOT_DIR}/bin/symqg_indexing" "${BASE}" 32 400 "${DATA_DIR}/symqg_32.index"
+run_and_log symqg_querying \
+    "${ROOT_DIR}/bin/symqg_querying" "${DATA_DIR}/symqg_32.index" "${QUERY}" "${GT}"
+
+run_and_log ivf_clustering_4096 \
+    python "${ROOT_DIR}/python/ivf.py" "${BASE}" 4096 \
+        "${DATA_DIR}/gist_centroids_4096.fvecs" "${DATA_DIR}/gist_clusterids_4096.ivecs"
+run_and_log ivf_rabitq_indexing \
+    "${ROOT_DIR}/bin/ivf_rabitq_indexing" "${BASE}" \
+        "${DATA_DIR}/gist_centroids_4096.fvecs" "${DATA_DIR}/gist_clusterids_4096.ivecs" \
+        3 "${DATA_DIR}/ivf_4096_3.index"
+run_and_log ivf_rabitq_querying \
+    "${ROOT_DIR}/bin/ivf_rabitq_querying" "${DATA_DIR}/ivf_4096_3.index" "${QUERY}" "${GT}"
+
+run_and_log hnsw_clustering_16 \
+    python "${ROOT_DIR}/python/ivf.py" "${BASE}" 16 \
+        "${DATA_DIR}/gist_centroids_16.fvecs" "${DATA_DIR}/gist_clusterids_16.ivecs"
+run_and_log hnsw_rabitq_indexing \
+    "${ROOT_DIR}/bin/hnsw_rabitq_indexing" "${BASE}" \
+        "${DATA_DIR}/gist_centroids_16.fvecs" "${DATA_DIR}/gist_clusterids_16.ivecs" \
+        16 200 5 "${DATA_DIR}/hnsw_5.index"
+run_and_log hnsw_rabitq_querying \
+    "${ROOT_DIR}/bin/hnsw_rabitq_querying" "${DATA_DIR}/hnsw_5.index" "${QUERY}" "${GT}"
+
+echo
+echo "===== recall summaries ====="
+print_recall_summary symqg_querying
+print_recall_summary ivf_rabitq_querying
+print_recall_summary hnsw_rabitq_querying

--- a/example.sh
+++ b/example.sh
@@ -1,101 +1,28 @@
-#!/usr/bin/env bash
-set -euo pipefail
+# compiling 
+mkdir build bin 
+cd build 
+cmake ..
+make 
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DATA_DIR="${DATA_DIR:-${ROOT_DIR}/data/gist}"
-LOG_DIR="${LOG_DIR:-${ROOT_DIR}/results/gist_example}"
-BUILD_JOBS="${BUILD_JOBS:-$(nproc)}"
+# Download the dataset
+wget -P ./data/gist ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz
+tar -xzvf ./data/gist/gist.tar.gz -C ./data/gist
 
-BASE="${DATA_DIR}/gist_base.fvecs"
-QUERY="${DATA_DIR}/gist_query.fvecs"
-GT="${DATA_DIR}/gist_groundtruth.ivecs"
+# indexing and querying for symqg
+./bin/symqg_indexing ./data/gist/gist_base.fvecs 32 400 ./data/gist/symqg_32.index
 
-mkdir -p "${ROOT_DIR}/bin" "${DATA_DIR}" "${LOG_DIR}"
-cd "${ROOT_DIR}"
+./bin/symqg_querying ./data/gist/symqg_32.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs
 
-run_and_log() {
-    local name="$1"
-    shift
-    local log_file="${LOG_DIR}/${name}.log"
+# indexing and querying for RabitQ+ with ivf, please refer to python/ivf.py for more information about clustering
+python ./python/ivf.py ./data/gist/gist_base.fvecs 4096 ./data/gist/gist_centroids_4096.fvecs ./data/gist/gist_clusterids_4096.ivecs
 
-    echo
-    echo "===== ${name} ====="
-    "$@" 2>&1 | tee "${log_file}"
-}
+./bin/ivf_rabitq_indexing ./data/gist/gist_base.fvecs ./data/gist/gist_centroids_4096.fvecs ./data/gist/gist_clusterids_4096.ivecs 3 ./data/gist/ivf_4096_3.index
 
-print_recall_summary() {
-    local name="$1"
-    local log_file="${LOG_DIR}/${name}.log"
+./bin/ivf_rabitq_querying ./data/gist/ivf_4096_3.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs
 
-    echo
-    echo "----- ${name} summary -----"
-    awk '
-        BEGIN { IGNORECASE = 1 }
-        /^[[:space:]]*(EF|nprobe)[[:space:]]/ {
-            in_table = 1
-            next
-        }
-        in_table && NF >= 3 && $1 ~ /^[0-9]+$/ {
-            last = $0
-            if (best_line == "" || ($3 + 0) > best_recall) {
-                best_recall = $3 + 0
-                best_line = $0
-            }
-        }
-        END {
-            if (best_line != "") {
-                print "best_recall_line: " best_line
-                print "last_line:        " last
-            } else {
-                print "No recall table found. Please inspect " FILENAME
-            }
-        }
-    ' "${log_file}"
-}
+# indexing and querying for RabitQ+ with hnsw, do clustering first
+python ./python/ivf.py ./data/gist/gist_base.fvecs 16 ./data/gist/gist_centroids_16.fvecs ./data/gist/gist_clusterids_16.ivecs
 
-echo "===== build ====="
-cmake -S "${ROOT_DIR}" -B "${ROOT_DIR}/build"
-cmake --build "${ROOT_DIR}/build" -j "${BUILD_JOBS}"
+./bin/hnsw_rabitq_indexing ./data/gist/gist_base.fvecs ./data/gist/gist_centroids_16.fvecs ./data/gist/gist_clusterids_16.ivecs 16 200 5 ./data/gist/hnsw_5.index
 
-if [[ ! -f "${BASE}" || ! -f "${QUERY}" || ! -f "${GT}" ]]; then
-    echo
-    echo "===== download gist ====="
-    if [[ ! -f "${DATA_DIR}/gist.tar.gz" ]]; then
-        wget -P "${DATA_DIR}" ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz
-    fi
-    tar -xzvf "${DATA_DIR}/gist.tar.gz" -C "${DATA_DIR}"
-fi
-
-echo
-echo "Logs will be written to ${LOG_DIR}"
-
-run_and_log symqg_indexing \
-    "${ROOT_DIR}/bin/symqg_indexing" "${BASE}" 32 400 "${DATA_DIR}/symqg_32.index"
-run_and_log symqg_querying \
-    "${ROOT_DIR}/bin/symqg_querying" "${DATA_DIR}/symqg_32.index" "${QUERY}" "${GT}"
-
-run_and_log ivf_clustering_4096 \
-    python "${ROOT_DIR}/python/ivf.py" "${BASE}" 4096 \
-        "${DATA_DIR}/gist_centroids_4096.fvecs" "${DATA_DIR}/gist_clusterids_4096.ivecs"
-run_and_log ivf_rabitq_indexing \
-    "${ROOT_DIR}/bin/ivf_rabitq_indexing" "${BASE}" \
-        "${DATA_DIR}/gist_centroids_4096.fvecs" "${DATA_DIR}/gist_clusterids_4096.ivecs" \
-        3 "${DATA_DIR}/ivf_4096_3.index"
-run_and_log ivf_rabitq_querying \
-    "${ROOT_DIR}/bin/ivf_rabitq_querying" "${DATA_DIR}/ivf_4096_3.index" "${QUERY}" "${GT}"
-
-run_and_log hnsw_clustering_16 \
-    python "${ROOT_DIR}/python/ivf.py" "${BASE}" 16 \
-        "${DATA_DIR}/gist_centroids_16.fvecs" "${DATA_DIR}/gist_clusterids_16.ivecs"
-run_and_log hnsw_rabitq_indexing \
-    "${ROOT_DIR}/bin/hnsw_rabitq_indexing" "${BASE}" \
-        "${DATA_DIR}/gist_centroids_16.fvecs" "${DATA_DIR}/gist_clusterids_16.ivecs" \
-        16 200 5 "${DATA_DIR}/hnsw_5.index"
-run_and_log hnsw_rabitq_querying \
-    "${ROOT_DIR}/bin/hnsw_rabitq_querying" "${DATA_DIR}/hnsw_5.index" "${QUERY}" "${GT}"
-
-echo
-echo "===== recall summaries ====="
-print_recall_summary symqg_querying
-print_recall_summary ivf_rabitq_querying
-print_recall_summary hnsw_rabitq_querying
+./bin/hnsw_rabitq_querying ./data/gist/hnsw_5.index ./data/gist/gist_query.fvecs ./data/gist/gist_groundtruth.ivecs

--- a/include/rabitqlib/index/estimator.hpp
+++ b/include/rabitqlib/index/estimator.hpp
@@ -201,7 +201,7 @@ inline void split_single_estdist(
 
     ip_x0_qr = warmup_ip_x0_q_512(
         cur_bin.bin_code(),
-        q_obj.transposed_query_bin(),
+        q_obj.query_bin(),
         q_obj.delta(),
         q_obj.vl(),
         padded_dim,

--- a/include/rabitqlib/index/estimator.hpp
+++ b/include/rabitqlib/index/estimator.hpp
@@ -199,13 +199,13 @@ inline void split_single_estdist(
 ) {
     ConstBinDataMap<float> cur_bin(bin_data, padded_dim);
 
-    ip_x0_qr = warmup_ip_x0_q<SplitSingleQuery<float>::kNumBits>(
+    ip_x0_qr = warmup_ip_x0_q_512(
         cur_bin.bin_code(),
         q_obj.transposed_query_bin(),
         q_obj.delta(),
         q_obj.vl(),
         padded_dim,
-        SplitSingleQuery<float>::kNumBits
+        q_obj.num_bits()
     );
 
     est_dist =

--- a/include/rabitqlib/index/query.hpp
+++ b/include/rabitqlib/index/query.hpp
@@ -114,7 +114,6 @@ class SplitSingleQuery {
    private:
     const T* rotated_query_;
     std::vector<uint64_t> QueryBin_;
-    std::vector<uint64_t> TransposedQueryBin_;
     T G_add_;
     T G_k1xSumq_;
     T G_kbxSumq_;
@@ -122,17 +121,6 @@ class SplitSingleQuery {
     T delta_;
     T vl_;
     MetricType metric_type_ = METRIC_L2;
-
-    void transpose_query_bin(size_t num_blk, size_t b_query) {
-        TransposedQueryBin_.resize(num_blk * b_query);
-
-        for (size_t i = 0; i < num_blk; ++i) {
-            for (size_t j = 0; j < b_query; ++j) {
-                TransposedQueryBin_[j * num_blk + i] =
-                    QueryBin_[i * b_query + j];
-            }
-        }
-    }
 
    public:
     static constexpr size_t kNumBits = 4;
@@ -166,15 +154,13 @@ class SplitSingleQuery {
             quant_query.data(), QueryBin_.data(), padded_dim, kNumBits
         );
 
-        size_t num_blk = padded_dim / 64;
-        transpose_query_bin(num_blk, kNumBits);
+        // new_transpose_bin_512 already stores the query in the bit-plane/chunk
+        // layout consumed by warmup_ip_x0_q_512.
     }
 
     [[nodiscard]] size_t num_bits() const { return kNumBits; }
 
     [[nodiscard]] const uint64_t* query_bin() const { return QueryBin_.data(); }
-
-    [[nodiscard]] const uint64_t* transposed_query_bin() const { return TransposedQueryBin_.data(); }
 
     [[nodiscard]] const T* rotated_query() const { return rotated_query_; }
 

--- a/include/rabitqlib/index/query.hpp
+++ b/include/rabitqlib/index/query.hpp
@@ -154,21 +154,23 @@ class SplitSingleQuery {
 
         metric_type_ = (metric_type == METRIC_IP) ? METRIC_IP : METRIC_L2;
 
-        std::vector<uint16_t> quant_query = std::vector<uint16_t>(padded_dim);
+        std::vector<uint8_t> quant_query(padded_dim);
 
         // quantize query by rabitq
-        quant::quantize_scalar<float, uint16_t>(
+        quant::quantize_scalar<float, uint8_t>(
             rotated_query, padded_dim, kNumBits, quant_query.data(), delta_, vl_, config
         );
 
         // represent quantized query as u64
-        rabitqlib::new_transpose_bin(
+        rabitqlib::new_transpose_bin_512(
             quant_query.data(), QueryBin_.data(), padded_dim, kNumBits
         );
 
         size_t num_blk = padded_dim / 64;
         transpose_query_bin(num_blk, kNumBits);
     }
+
+    [[nodiscard]] size_t num_bits() const { return kNumBits; }
 
     [[nodiscard]] const uint64_t* query_bin() const { return QueryBin_.data(); }
 

--- a/include/rabitqlib/utils/space.hpp
+++ b/include/rabitqlib/utils/space.hpp
@@ -925,7 +925,8 @@ static inline void new_transpose_bin_512(
             for (size_t j = 0; j < b_query; ++j) {
                 int bit_idx = b_query - 1 - j;
                 __mmask64 m = _mm512_test_epi8_mask(vec, _mm512_set1_epi8(1 << bit_idx));
-                tq[(b_query - j - 1) * num_chunks + k] = static_cast<uint64_t>(m);
+                tq[(b_query - j - 1) * num_chunks + k] =
+                    reverse_bits_u64(static_cast<uint64_t>(m));
             }
         }
 

--- a/include/rabitqlib/utils/space.hpp
+++ b/include/rabitqlib/utils/space.hpp
@@ -905,6 +905,39 @@ static inline void new_transpose_bin(
 #endif
 }
 
+static inline void new_transpose_bin_512(
+    const uint8_t* q, uint64_t* tq, size_t padded_dim, size_t b_query
+) {
+#if defined(__AVX512BW__)
+    // Keep full 512-dim blocks as 8 chunks, but store the tail as compact
+    // [b_query x num_chunks] so runtime can use maskz loads without query padding.
+    for (size_t i = 0; i < padded_dim;) {
+        size_t block_size = 512;
+        if (i + 512 > padded_dim) {
+            block_size = padded_dim - i;
+        }
+        size_t num_chunks = block_size / 64;
+
+        for (size_t k = 0; k < num_chunks; ++k) {
+            const uint8_t* current_q = q + i + k * 64;
+            __m512i vec = _mm512_loadu_si512(current_q);
+
+            for (size_t j = 0; j < b_query; ++j) {
+                int bit_idx = b_query - 1 - j;
+                __mmask64 m = _mm512_test_epi8_mask(vec, _mm512_set1_epi8(1 << bit_idx));
+                tq[(b_query - j - 1) * num_chunks + k] = static_cast<uint64_t>(m);
+            }
+        }
+
+        i += block_size;
+        tq += num_chunks * b_query;
+    }
+#else
+    std::cerr << "AVX512BW is required for new_transpose_bin_512\n";
+    exit(1);
+#endif
+}
+
 inline float mask_ip_x0_q_old(const float* query, const uint64_t* data, size_t padded_dim) {
     auto num_blk = padded_dim / 64;
     const auto* it_data = data;

--- a/include/rabitqlib/utils/warmup_space.hpp
+++ b/include/rabitqlib/utils/warmup_space.hpp
@@ -34,6 +34,76 @@ inline __m256i popcount_avx2(__m256i v) {
 #endif
 }
 
+inline float warmup_ip_x0_q_512(
+    const uint64_t* data,
+    const uint64_t* query,
+    float delta,
+    float vl,
+    size_t padded_dim,
+    size_t b_query
+) {
+#if defined(__AVX512VPOPCNTDQ__) && defined(__AVX512BW__)
+    size_t ip_scalar = 0;
+    size_t ppc_scalar = 0;
+
+    __m512i acc_ip = _mm512_setzero_si512();
+    __m512i acc_ppc = _mm512_setzero_si512();
+
+    size_t i = 0;
+    size_t dim_end_512 = (padded_dim / 512) * 512;
+
+    __m512i acc_bits[b_query];
+    for (size_t j = 0; j < b_query; ++j) {
+        acc_bits[j] = _mm512_setzero_si512();
+    }
+
+    for (; i < dim_end_512; i += 512) {
+        __m512i data_vec = _mm512_loadu_si512(data);
+        data += 8;
+
+        acc_ppc = _mm512_add_epi64(acc_ppc, _mm512_popcnt_epi64(data_vec));
+
+        for (size_t j = 0; j < b_query; ++j) {
+            __m512i query_vec = _mm512_loadu_si512(query);
+            query += 8;
+
+            __m512i pop = _mm512_popcnt_epi64(_mm512_and_si512(data_vec, query_vec));
+            acc_bits[j] = _mm512_add_epi64(acc_bits[j], pop);
+        }
+    }
+
+    size_t remaining_dim = padded_dim - i;
+    if (remaining_dim > 0) {
+        size_t num_chunks = remaining_dim / 64;
+        auto valid_mask = static_cast<__mmask8>((1u << num_chunks) - 1u);
+
+        __m512i data_vec = _mm512_maskz_loadu_epi64(valid_mask, data);
+        acc_ppc = _mm512_add_epi64(acc_ppc, _mm512_popcnt_epi64(data_vec));
+
+        for (size_t j = 0; j < b_query; ++j) {
+            __m512i query_vec = _mm512_maskz_loadu_epi64(valid_mask, query);
+            query += num_chunks;
+
+            __m512i pop = _mm512_popcnt_epi64(_mm512_and_si512(data_vec, query_vec));
+            acc_bits[j] = _mm512_add_epi64(acc_bits[j], pop);
+        }
+    }
+
+    for (size_t j = 0; j < b_query; ++j) {
+        __m128i shift = _mm_cvtsi32_si128(static_cast<int>(j));
+        acc_ip = _mm512_add_epi64(acc_ip, _mm512_sll_epi64(acc_bits[j], shift));
+    }
+
+    ip_scalar += static_cast<size_t>(_mm512_reduce_add_epi64(acc_ip));
+    ppc_scalar += static_cast<size_t>(_mm512_reduce_add_epi64(acc_ppc));
+
+    return (delta * static_cast<float>(ip_scalar)) + (vl * static_cast<float>(ppc_scalar));
+#else
+    std::cerr << "AVX512 VPOPCNTDQ and AVX512BW are required for warmup_ip_x0_q_512\n";
+    exit(1);
+#endif
+}
+
 template <uint32_t b_query>
 inline float warmup_ip_x0_q(
     const uint64_t* data,   // pointer to data blocks (each 64 bits)


### PR DESCRIPTION
## Tail-pad report

### 1. What problem does tail-pad address?

The 1-bit estimator is built around an AVX-512 512-dimensional path.  
When the input dimension is not a multiple of 512, the remaining non-full block has to be handled separately. In the original path, this tail part is processed in a more conventional way, which leads to lower SIMD utilization and extra overhead on the final block. As a result, the estimator becomes noticeably slower when the tail is large.

### 2. Current tail-pad method

The current tail-pad method directly pads the remaining dimensions to a full 512-dimensional block, so the tail can stay on the same AVX-512 path as the main body.

In other words:

- full 512-dim blocks use the regular AVX-512 estimator path,
- the final partial block is padded to 512 dims,
- the estimator can then continue using 512-bit vector loads, bitwise operations, popcount, and reduction without falling back to a less efficient tail path.

This keeps the implementation simple and improves the utilization of the AVX-512 path on non-512-aligned dimensions.

### 3. Single-function results

The following table reports median per-call latency for the single-function benchmark (`warmup_ip_x0_q_512`) on the OpenAI-1536 dimension sweep.

| dim | remaining_dim | origin (ns) | 512-bit tail pad (ns) | speedup |
|---:|---:|---:|---:|---:|
| 256  | 256 | 17.5343 | 8.7724 | 50.0% |
| 320  | 320 | 20.1750 | 8.7747 | 56.5% |
| 384  | 384 | 23.1806 | 9.7438 | 58.0% |
| 448  | 448 | 25.9888 | 9.1661 | 64.7% |
| 512  | 0   | 10.1682 | 9.6581 | 5.0% |
| 640  | 128 | 14.7538 | 12.5987 | 14.6% |
| 768  | 256 | 20.1823 | 13.1654 | 34.8% |
| 960  | 448 | 29.5875 | 13.5227 | 54.3% |
| 1024 | 0   | 19.5496 | 18.9976 | 2.8% |
| 1280 | 256 | 26.5937 | 18.3340 | 31.1% |
| 1536 | 0   | 25.3903 | 24.8515 | 2.1% |

Overall, the gain is small when the dimension is already 512-aligned, but becomes significant when the remaining tail is large. The largest improvements appear when `remaining_dim` is close to `448`, where the tail overhead is most visible in the original path.
