### PR TITLE
Library preparation for bindings

### DIFF
--- a/include/rabitqlib/index/hnsw/hnsw.hpp
+++ b/include/rabitqlib/index/hnsw/hnsw.hpp
@@ -52,7 +52,7 @@ class HierarchicalNSW {
     [[nodiscard]] size_t max_elements() const { return max_elements_; }
 
     void save(const char*) const;
-    void load(const char*, MetricType metric_type_input);
+    void load(const char*);
 
     void construct(size_t, const float*, size_t, const float*, PID*, size_t, bool);
     std::vector<std::vector<std::pair<float, PID>>> search(
@@ -438,6 +438,7 @@ inline void HierarchicalNSW::save(const char* filename) const {
     output.write(reinterpret_cast<const char*>(&padded_dim_), sizeof(size_t));
     output.write(reinterpret_cast<const char*>(&num_cluster_), sizeof(size_t));
     output.write(reinterpret_cast<const char*>(&ex_bits_), sizeof(size_t));
+    output.write(reinterpret_cast<const char*>(&metric_type_), sizeof(metric_type_));
 
     output.write(reinterpret_cast<const char*>(&size_bin_data_), sizeof(size_t));
     output.write(reinterpret_cast<const char*>(&size_ex_data_), sizeof(size_t));
@@ -482,7 +483,7 @@ inline void HierarchicalNSW::save(const char* filename) const {
     output.close();
 }
 
-inline void HierarchicalNSW::load(const char* filename, MetricType metric_type_input) {
+inline void HierarchicalNSW::load(const char* filename) {
     std::ifstream input(filename, std::ios::binary);
 
     if (!input.is_open()) {
@@ -491,10 +492,6 @@ inline void HierarchicalNSW::load(const char* filename, MetricType metric_type_i
 
     free_memory();
 
-    raw_dist_func_ =
-        (metric_type_input == METRIC_IP) ? dot_product_dis<float> : euclidean_sqr<float>;
-    metric_type_ = (metric_type_input == METRIC_IP) ? METRIC_IP : METRIC_L2;
-
     input.read(reinterpret_cast<char*>(&max_elements_), sizeof(size_t));
     input.read(reinterpret_cast<char*>(&cur_element_count_), sizeof(size_t));
 
@@ -502,6 +499,9 @@ inline void HierarchicalNSW::load(const char* filename, MetricType metric_type_i
     input.read(reinterpret_cast<char*>(&padded_dim_), sizeof(size_t));
     input.read(reinterpret_cast<char*>(&num_cluster_), sizeof(size_t));
     input.read(reinterpret_cast<char*>(&ex_bits_), sizeof(size_t));
+    input.read(reinterpret_cast<char*>(&metric_type_), sizeof(metric_type_));
+    raw_dist_func_ =
+        (metric_type_ == METRIC_IP) ? dot_product_dis<float> : euclidean_sqr<float>;
 
     ip_func_ = select_excode_ipfunc(ex_bits_);
 

--- a/include/rabitqlib/index/hnsw/hnsw.hpp
+++ b/include/rabitqlib/index/hnsw/hnsw.hpp
@@ -43,6 +43,14 @@ class HierarchicalNSW {
     );
     ~HierarchicalNSW();
 
+    [[nodiscard]] size_t dimension() const { return dim_; }
+    [[nodiscard]] size_t num_clusters() const { return num_cluster_; }
+    [[nodiscard]] size_t nbits() const { return ex_bits_ + 1; }
+    [[nodiscard]] size_t M() const { return M_; }
+    [[nodiscard]] size_t ef_construction() const { return ef_construction_; }
+    [[nodiscard]] MetricType metric_type() const { return metric_type_; }
+    [[nodiscard]] size_t max_elements() const { return max_elements_; }
+
     void save(const char*) const;
     void load(const char*, MetricType metric_type_input);
 

--- a/include/rabitqlib/index/ivf/ivf.hpp
+++ b/include/rabitqlib/index/ivf/ivf.hpp
@@ -105,6 +105,12 @@ class IVF {
 
     ~IVF();
 
+    [[nodiscard]] size_t max_elements() const { return num_; }
+    [[nodiscard]] size_t dimension() const { return dim_; }
+    [[nodiscard]] size_t nbits() const { return ex_bits_ + 1; }
+    [[nodiscard]] MetricType metric_type() const { return metric_type_; }
+    [[nodiscard]] RotatorType rotator_type() const { return type_; }
+
     void construct(const float*, const float*, const PID*, bool);
 
     void save(const char*) const;
@@ -112,6 +118,8 @@ class IVF {
     void load(const char*);
 
     void search(const float*, size_t, size_t, PID*, bool) const;
+
+    void search(const float*, size_t, size_t, PID*, float*, bool) const;
 
     [[nodiscard]] size_t padded_dim() const { return this->padded_dim_; }
 
@@ -395,6 +403,17 @@ inline void IVF::search(
     PID* __restrict__ results,
     bool use_hacc = true
 ) const {
+    this->search(query, k, nprobe, results, nullptr, use_hacc);
+}
+
+inline void IVF::search(
+    const float* __restrict__ query,
+    size_t k,
+    size_t nprobe,
+    PID* __restrict__ results,
+    float* __restrict__ dists,
+    bool use_hacc
+) const {
     nprobe = std::min(nprobe, num_cluster_);  // corner case
     std::vector<float> rotated_query(padded_dim_);
     this->rotator_->rotate(query, rotated_query.data());
@@ -431,7 +450,11 @@ inline void IVF::search(
         search_cluster(cur_cluster, q_obj, knns, use_hacc);
     }
 
-    knns.copy_results(results);
+    if (dists != nullptr) {
+        knns.copy_results(results, dists);
+    } else {
+        knns.copy_results(results);
+    }
 }
 
 inline void IVF::search_cluster(

--- a/include/rabitqlib/utils/space.hpp
+++ b/include/rabitqlib/utils/space.hpp
@@ -925,8 +925,49 @@ static inline void new_transpose_bin_512(
             for (size_t j = 0; j < b_query; ++j) {
                 int bit_idx = b_query - 1 - j;
                 __mmask64 m = _mm512_test_epi8_mask(vec, _mm512_set1_epi8(1 << bit_idx));
-                tq[(b_query - j - 1) * num_chunks + k] =
-                    reverse_bits_u64(static_cast<uint64_t>(m));
+                tq[(b_query - j - 1) * num_chunks + k] = reverse_bits_u64(static_cast<uint64_t>(m));
+            }
+        }
+
+        i += block_size;
+        tq += num_chunks * b_query;
+    }
+#elif defined(__AVX2__)
+    for (size_t i = 0; i < padded_dim;) {
+        size_t block_size = 512;
+        if (i + 512 > padded_dim) {
+            block_size = padded_dim - i;
+        }
+        // Each chunk represents 64 bytes (512 bits) of dimensions
+        size_t num_chunks = block_size / 64;
+
+        for (size_t k = 0; k < num_chunks; ++k) {
+            // Load 64 bytes using two sequential 32-byte AVX2 registers
+            const uint8_t* current_q_lo = q + i + k * 64;
+            const uint8_t* current_q_hi = q + i + k * 64 + 32;
+
+            __m256i vec_lo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(current_q_lo));
+            __m256i vec_hi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(current_q_hi));
+
+            for (size_t j = 0; j < b_query; ++j) {
+                int bit_idx = b_query - 1 - j;
+                __m256i mask_vec = _mm256_set1_epi8(static_cast<char>(1 << bit_idx));
+
+                // Process lower 32 bytes
+                __m256i res_lo = _mm256_and_si256(vec_lo, mask_vec);
+                __m256i eq_lo = _mm256_cmpeq_epi8(res_lo, _mm256_setzero_si256());
+                uint32_t m_lo = ~static_cast<uint32_t>(_mm256_movemask_epi8(eq_lo));
+
+                // Process upper 32 bytes
+                __m256i res_hi = _mm256_and_si256(vec_hi, mask_vec);
+                __m256i eq_hi = _mm256_cmpeq_epi8(res_hi, _mm256_setzero_si256());
+                uint32_t m_hi = ~static_cast<uint32_t>(_mm256_movemask_epi8(eq_hi));
+
+                // Combine both 32-bit masks into a single 64-bit mask
+                uint64_t m = (static_cast<uint64_t>(m_hi) << 32) | m_lo;
+
+                // Write into the 64-bit structured macro-layout
+                tq[(b_query - j - 1) * num_chunks + k] = reverse_bits_u64(m);
             }
         }
 
@@ -934,7 +975,7 @@ static inline void new_transpose_bin_512(
         tq += num_chunks * b_query;
     }
 #else
-    std::cerr << "AVX512BW is required for new_transpose_bin_512\n";
+    std::cerr << "AVX512BW or AVX2 is required for new_transpose_bin_512\n";
     exit(1);
 #endif
 }

--- a/include/rabitqlib/utils/warmup_space.hpp
+++ b/include/rabitqlib/utils/warmup_space.hpp
@@ -98,8 +98,105 @@ inline float warmup_ip_x0_q_512(
     ppc_scalar += static_cast<size_t>(_mm512_reduce_add_epi64(acc_ppc));
 
     return (delta * static_cast<float>(ip_scalar)) + (vl * static_cast<float>(ppc_scalar));
-#else
-    std::cerr << "AVX512 VPOPCNTDQ and AVX512BW are required for warmup_ip_x0_q_512\n";
+#elif defined(__AVX2__)
+    size_t ip_scalar = 0;
+    size_t ppc_scalar = 0;
+
+    __m256i acc_ip = _mm256_setzero_si256();
+    __m256i acc_ppc = _mm256_setzero_si256();
+
+    size_t i = 0;
+    // Step by 512 bits at a time (64 bytes = 16 elements of 32-bit integers)
+    size_t dim_end_512 = (padded_dim / 512) * 512;
+
+    __m256i acc_bits[b_query];
+    for (size_t j = 0; j < b_query; ++j) {
+        acc_bits[j] = _mm256_setzero_si256();
+    }
+
+    for (; i < dim_end_512; i += 512) {
+        // Load 64 bytes of data using paired 32-byte loads
+        __m256i data_vec_lo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data));
+        __m256i data_vec_hi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data + 4));
+        data += 8; // Advance 8 x 64-bit ints (64 bytes)
+
+        acc_ppc = _mm256_add_epi64(acc_ppc, popcount_avx2(data_vec_lo));
+        acc_ppc = _mm256_add_epi64(acc_ppc, popcount_avx2(data_vec_hi));
+
+        for (size_t j = 0; j < b_query; ++j) {
+            // Load 64 bytes of transposed query matching the 512-bit block layout
+            __m256i query_vec_lo = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query));
+            __m256i query_vec_hi = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(query + 4));
+            query += 8; // Advance 8 x 64-bit ints (64 bytes)
+
+            __m256i pop_lo = popcount_avx2(_mm256_and_si256(data_vec_lo, query_vec_lo));
+            __m256i pop_hi = popcount_avx2(_mm256_and_si256(data_vec_hi, query_vec_hi));
+            
+            acc_bits[j] = _mm256_add_epi64(acc_bits[j], pop_lo);
+            acc_bits[j] = _mm256_add_epi64(acc_bits[j], pop_hi);
+        }
+    }
+
+    // Remainder block: handles leftovers less than 512 bits wide (e.g., last 448 bits)
+    size_t remaining_dim = padded_dim - i;
+    if (remaining_dim > 0) {
+        size_t num_chunks_64 = remaining_dim / 64;
+        size_t num_chunks_32 = remaining_dim / 32;
+
+        size_t chunks_lo = (num_chunks_32 > 8) ? 8 : num_chunks_32;
+        size_t chunks_hi = (num_chunks_32 > 8) ? (num_chunks_32 - 8) : 0;
+
+        // 1. Create a baseline sequence register
+        __m256i sequence = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+
+        // 2. Generate masks in-register using Greater-Than comparisons
+        // If chunks_lo is 3, limit will be [3,3,3,3,3,3,3,3]. 
+        // 3 > seq results in [-1, -1, -1, 0, 0, 0, 0, 0], which is the exact mask needed.
+        __m256i limit_lo = _mm256_set1_epi32(static_cast<int>(chunks_lo));
+        __m256i mask_lo  = _mm256_cmpgt_epi32(limit_lo, sequence);
+
+        __m256i limit_hi = _mm256_set1_epi32(static_cast<int>(chunks_hi));
+        __m256i mask_hi  = _mm256_cmpgt_epi32(limit_hi, sequence);
+
+        // 3. Vectorized execution continues with zero memory latency
+        __m256i data_vec_lo = _mm256_maskload_epi32(reinterpret_cast<const int*>(data), mask_lo);
+        __m256i data_vec_hi = _mm256_maskload_epi32(reinterpret_cast<const int*>(data + 4), mask_hi);
+        
+        acc_ppc = _mm256_add_epi64(acc_ppc, popcount_avx2(data_vec_lo));
+        acc_ppc = _mm256_add_epi64(acc_ppc, popcount_avx2(data_vec_hi));
+
+        for (size_t j = 0; j < b_query; ++j) {
+            __m256i query_vec_lo = _mm256_maskload_epi32(reinterpret_cast<const int*>(query), mask_lo);
+            __m256i query_vec_hi = _mm256_maskload_epi32(reinterpret_cast<const int*>(query + 4), mask_hi);
+            query += num_chunks_64;
+
+            __m256i pop_lo = popcount_avx2(_mm256_and_si256(data_vec_lo, query_vec_lo));
+            __m256i pop_hi = popcount_avx2(_mm256_and_si256(data_vec_hi, query_vec_hi));
+            
+            acc_bits[j] = _mm256_add_epi64(acc_bits[j], pop_lo);
+            acc_bits[j] = _mm256_add_epi64(acc_bits[j], pop_hi);
+        }
+    }
+
+    for (size_t j = 0; j < b_query; ++j) {
+        __m128i shift = _mm_cvtsi32_si128(static_cast<int>(j));
+        acc_ip = _mm256_add_epi64(acc_ip, _mm256_sll_epi64(acc_bits[j], shift));
+    }
+
+    // Standard reduction for a single __m256i
+    auto mm256_reduce_add_epi64 = [](__m256i v) {
+        __m128i low = _mm256_castsi256_si128(v);
+        __m128i high = _mm256_extracti128_si256(v, 1);
+        __m128i sum = _mm_add_epi64(low, high);
+        return _mm_extract_epi64(sum, 0) + _mm_extract_epi64(sum, 1);
+    };
+
+    ip_scalar += mm256_reduce_add_epi64(acc_ip);
+    ppc_scalar += mm256_reduce_add_epi64(acc_ppc);
+
+    return (delta * static_cast<float>(ip_scalar)) + (vl * static_cast<float>(ppc_scalar));
+#else    
+    std::cerr << "AVX512 VPOPCNTDQ and AVX512BW or AVX2 are required for warmup_ip_x0_q_512\n";
     exit(1);
 #endif
 }

--- a/sample/hnsw_rabitq_querying.cpp
+++ b/sample/hnsw_rabitq_querying.cpp
@@ -17,12 +17,11 @@ using data_type = rabitqlib::RowMajorArray<float>;
 using gt_type = rabitqlib::RowMajorArray<uint32_t>;
 
 int main(int argc, char* argv[]) {
-    if (argc < 4) {
-        std::cerr << "Usage: " << argv[0] << " <arg1> <arg2> <arg3> <arg4>\n"
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " <arg1> <arg2> <arg3>\n"
                   << "arg1: path for index \n"
                   << "arg2: path for query file, format .fvecs\n"
-                  << "arg3: path for groundtruth file format .ivecs\n"
-                  << "arg4: metric type (\"l2\" or \"ip\")\n";
+                  << "arg3: path for groundtruth file format .ivecs\n";
         exit(1);
     }
 
@@ -38,20 +37,8 @@ int main(int argc, char* argv[]) {
     size_t total_count = nq * topk;
 
     index_type hnsw;
-    rabitqlib::MetricType metric_type = rabitqlib::METRIC_L2;
-    if (argc > 4) {
-        std::string metric_str(argv[4]);
-        if (metric_str == "ip" || metric_str == "IP") {
-            metric_type = rabitqlib::METRIC_IP;
-        }
-    }
-    if (metric_type == rabitqlib::METRIC_IP) {
-        std::cout << "Metric Type: IP\n";
-    } else if (metric_type == rabitqlib::METRIC_L2) {
-        std::cout << "Metric Type: L2\n";
-    }
 
-    hnsw.load(index_file, metric_type);
+    hnsw.load(index_file);
 
     rabitqlib::StopW stopw;
 


### PR DESCRIPTION
This PR prepares the library for the upcoming bindings initialization.

- Adds getters for HNSW and IVF index properties. The SymQG already exposes those properties, so no change needed there
- Re-adds full avx2 support which was absent due to the PR #51 
- Includes metric type in the hnsw index file, thus not requiring the metric type in `load`. 

> [!IMPORTANT]  
> Previously created index file will need to be recreated using the new `save` method for compatibility. This change was discussed with the maintainer beforehand.

There is no need for performance measurement as no change in algorithm or logic is introduced.