### PR TITLE
Refactor 8 bit path for better performance

### DIFF
--- a/include/rabitqlib/simd/space_dispatch.hpp
+++ b/include/rabitqlib/simd/space_dispatch.hpp
@@ -13,7 +13,7 @@ float ip16_fxu4_avx2(const float* __restrict__ query, const uint8_t* __restrict_
 float ip64_fxu5_avx2(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
 float ip64_fxu6_avx2(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
 float ip64_fxu7_avx2(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
-float ip_fxu8_avx2(const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim);
+float ip16_fxu8_avx2(const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim);
 
 float ip16_fxu1_avx512(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
 float ip64_fxu2_avx512(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
@@ -22,7 +22,7 @@ float ip16_fxu4_avx512(const float* __restrict__ query, const uint8_t* __restric
 float ip64_fxu5_avx512(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
 float ip64_fxu6_avx512(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
 float ip64_fxu7_avx512(const float* __restrict__ query, const uint8_t* __restrict__ compact_code, size_t dim);
-float ip_fxu8_avx512(const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim);
+float ip16_fxu8_avx512(const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim);
 
 }  // namespace excode_ipimpl
 

--- a/src/simd/dispatch.cpp
+++ b/src/simd/dispatch.cpp
@@ -29,7 +29,7 @@ ExcodeIpTable resolve_excode_ip_table() {
             excode_ipimpl::ip64_fxu5_avx512,
             excode_ipimpl::ip64_fxu6_avx512,
             excode_ipimpl::ip64_fxu7_avx512,
-            excode_ipimpl::ip_fxu8_avx512,
+            excode_ipimpl::ip16_fxu8_avx512,
         };
     } else if (cpu::has_avx2()) {
         return {
@@ -41,7 +41,7 @@ ExcodeIpTable resolve_excode_ip_table() {
             excode_ipimpl::ip64_fxu5_avx2,
             excode_ipimpl::ip64_fxu6_avx2,
             excode_ipimpl::ip64_fxu7_avx2,
-            excode_ipimpl::ip_fxu8_avx2,
+            excode_ipimpl::ip16_fxu8_avx2,
         };
     } else {
         missing_feature("excode ip functions");

--- a/src/simd/space_excode_avx2.cpp
+++ b/src/simd/space_excode_avx2.cpp
@@ -319,7 +319,7 @@ float ip16_fxu8_avx2(
     __m256 sum = _mm256_setzero_ps();
     for (size_t i = 0; i < dim; i += 16) {
         __m128i c8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(code));
-        contribute_ip_signed(c8, &query[i], sum);
+        contribute_ip(c8, &query[i], sum);
         code += 16;
     }
     return mm256_reduce_add_ps(sum);

--- a/src/simd/space_excode_avx2.cpp
+++ b/src/simd/space_excode_avx2.cpp
@@ -313,12 +313,16 @@ float ip64_fxu7_avx2(
     return result;
 }
 
-float ip_fxu8_avx2(
+float ip16_fxu8_avx2(
     const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim
 ) {
-    ConstVectorMap<float> query_map(query, dim);
-    ConstVectorMap<uint8_t> code_map(code, dim);
-    return query_map.dot(code_map.cast<float>());
+    __m256 sum = _mm256_setzero_ps();
+    for (size_t i = 0; i < dim; i += 16) {
+        __m128i c8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(code));
+        contribute_ip_signed(c8, &query[i], sum);
+        code += 16;
+    }
+    return mm256_reduce_add_ps(sum);
 }
 
 }  // namespace rabitqlib::simd::excode_ipimpl

--- a/src/simd/space_excode_avx512.cpp
+++ b/src/simd/space_excode_avx512.cpp
@@ -354,7 +354,7 @@ float ip16_fxu8_avx512(
     for (size_t i = 0; i < dim; i += 16) {
         __m128i c8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(code));
         __m512 q = _mm512_loadu_ps(&query[i]);
-        __m512 cf = _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(c8));
+        __m512 cf = _mm512_cvtepi32_ps(_mm512_cvtepu8_epi32(c8));
         sum = _mm512_fmadd_ps(cf, q, sum);
         code += 16;
     }

--- a/src/simd/space_excode_avx512.cpp
+++ b/src/simd/space_excode_avx512.cpp
@@ -347,12 +347,18 @@ float ip64_fxu7_avx512(
     return result;
 }
 
-float ip_fxu8_avx512(
+float ip16_fxu8_avx512(
     const float* __restrict__ query, const uint8_t* __restrict__ code, size_t dim
 ) {
-    ConstVectorMap<float> query_map(query, dim);
-    ConstVectorMap<uint8_t> code_map(code, dim);
-    return query_map.dot(code_map.cast<float>());
+    __m512 sum = _mm512_setzero_ps();
+    for (size_t i = 0; i < dim; i += 16) {
+        __m128i c8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(code));
+        __m512 q = _mm512_loadu_ps(&query[i]);
+        __m512 cf = _mm512_cvtepi32_ps(_mm512_cvtepi8_epi32(c8));
+        sum = _mm512_fmadd_ps(cf, q, sum);
+        code += 16;
+    }
+    return _mm512_reduce_add_ps(sum);
 }
 
 }  // namespace rabitqlib::simd::excode_ipimpl

--- a/tests/unit/rabitqlib/utils/space_test.cpp
+++ b/tests/unit/rabitqlib/utils/space_test.cpp
@@ -47,9 +47,9 @@ TEST(Select_IP_Func, returns_stable_function_pointer) {
     ip_func = select_excode_ipfunc(8);
     ASSERT_NE(ip_func, nullptr);
     if (cpu::has_avx512_core()) {
-        ASSERT_EQ(ip_func, simd::excode_ipimpl::ip_fxu8_avx512);
+        ASSERT_EQ(ip_func, simd::excode_ipimpl::ip16_fxu8_avx512);
     } else {
-        ASSERT_EQ(ip_func, simd::excode_ipimpl::ip_fxu8_avx2);
+        ASSERT_EQ(ip_func, simd::excode_ipimpl::ip16_fxu8_avx2);
     }
 }
 
@@ -141,14 +141,14 @@ TEST(ip_fxu8_avx, ip_works) {
     ASSERT_NEAR(ip_func(query.data(), codes.data(), dim), expected_float, 0.1F);
     if (cpu::has_avx2()) {
         ASSERT_NEAR(
-            simd::excode_ipimpl::ip_fxu8_avx2(query.data(), codes.data(), dim),
+            simd::excode_ipimpl::ip16_fxu8_avx2(query.data(), codes.data(), dim),
             expected_float,
             0.1F
         );
     }
     if (cpu::has_avx512_core()) {
         ASSERT_NEAR(
-            simd::excode_ipimpl::ip_fxu8_avx512(query.data(), codes.data(), dim),
+            simd::excode_ipimpl::ip16_fxu8_avx512(query.data(), codes.data(), dim),
             expected_float,
             0.1F
         );


### PR DESCRIPTION
The previous implementation of 8 bit excode used generic eigen code which caused performance degradation compared to other bits.

## Comparision 
```
total bit count 1 : 0.41252 seconds
total bit count 2 : 0.382485 seconds
total bit count 3 : 0.440617 seconds
total bit count 4 : 0.443649 seconds
total bit count 5 : 0.549168 seconds
total bit count 6 : 0.585995 seconds
total bit count 7 : 0.533338 seconds
total bit count 8 : 0.457026 seconds
total bit count 9 : 1.41387 seconds
```
It is apparent that the 8 bit excode takes about 10 times more time than others.

## After
```
total bit count 9 : 0.457035 seconds
```
After refactoring the code to raw avx codes, the runtime comes down to expected range.