### PR TITLE
fix: reject out-of-range cluster ids in IVF construction

### DIFF
--- a/include/rabitqlib/index/ivf/ivf.hpp
+++ b/include/rabitqlib/index/ivf/ivf.hpp
@@ -178,7 +178,7 @@ inline void IVF::construct(
     std::vector<std::vector<PID>> id_lists(num_cluster_);
     for (size_t i = 0; i < num_; ++i) {
         PID cid = cluster_ids[i];
-        if (cid > num_cluster_) {
+        if (cid >= num_cluster_) {
             std::cerr << "Bad cluster id\n";
             exit(1);
         }


### PR DESCRIPTION
The bounds check was off by one, so a bad cluster id could write past the end of the array.