### PR TITLE
Fix ex_bits=0 slot in excode IP dispatch table

### DIFF
--- a/src/simd/dispatch.cpp
+++ b/src/simd/dispatch.cpp
@@ -20,10 +20,19 @@ namespace rabitqlib::simd {
     );
 }
 
+// With zero extra bits there is no extra code to contribute to the inner
+// product, so the ex_bits == 0 slot must be a constant-zero stub rather than
+// a duplicate of the 1-bit implementation.
+static float ip_fxu0(
+    const float* /*query*/, const uint8_t* /*compact_code*/, size_t /*dim*/
+) {
+    return 0.0F;
+}
+
 ExcodeIpTable resolve_excode_ip_table() {
     if (cpu::has_avx512_core()) {
         return {
-            excode_ipimpl::ip16_fxu1_avx512,
+            ip_fxu0,
             excode_ipimpl::ip16_fxu1_avx512,
             excode_ipimpl::ip64_fxu2_avx512,
             excode_ipimpl::ip64_fxu3_avx512,
@@ -35,7 +44,7 @@ ExcodeIpTable resolve_excode_ip_table() {
         };
     } else if (cpu::has_avx2()) {
         return {
-            excode_ipimpl::ip16_fxu1_avx2,
+            ip_fxu0,
             excode_ipimpl::ip16_fxu1_avx2,
             excode_ipimpl::ip64_fxu2_avx2,
             excode_ipimpl::ip64_fxu3_avx2,

--- a/tests/unit/rabitqlib/utils/space_test.cpp
+++ b/tests/unit/rabitqlib/utils/space_test.cpp
@@ -55,6 +55,23 @@ TEST(Select_IP_Func, returns_stable_function_pointer) {
     }
 }
 
+TEST(Select_IP_Func, zero_ex_bits_contributes_nothing) {
+    constexpr size_t dim = 64;
+    std::vector<float> query(dim);
+    std::vector<uint8_t> codes(dim / 8);
+
+    for (size_t i = 0; i < dim; ++i) {
+        query[i] = static_cast<float>(i) + 1.0F;
+    }
+    for (size_t i = 0; i < codes.size(); ++i) {
+        codes[i] = 0xFF;
+    }
+
+    ex_ipfunc ip_func = select_excode_ipfunc(0);
+    ASSERT_NE(ip_func, nullptr);
+    ASSERT_EQ(ip_func(query.data(), codes.data(), dim), 0.0F);
+}
+
 TEST(ScalarQuantize, Uint8MatchesRoundedScalar) {
     constexpr size_t dim = 37;
     constexpr float lo = -3.0F;


### PR DESCRIPTION
`resolve_excode_ip_table()` fills index 0 (zero extra bits) with a duplicate
of `ip16_fxu1_avx{512,2}`, the 1-bit kernel, instead of a function that
contributes zero to the inner product. Since `select_excode_ipfunc(ex_bits)`
indexes this table directly by `ex_bits`, any code path with zero extra bits
ends up calling the 1-bit kernel on nonexistent extra-code data, corrupting
the inner product.

This adds a small `ip_fxu0` stub that always returns `0.0F` and puts it at
index 0 for both the AVX-512 and AVX2 tables, and adds a regression test
(`Select_IP_Func.zero_ex_bits_contributes_nothing`) that fails on the old
code and passes with the fix.

Tested: full CMake build + `ctest` suite (32/32 passing), formatting clean
against `.clang-format`.