### PR TITLE
Enable HNSW index arrays with transparent huge pages

### DIFF
--- a/include/rabitqlib/index/hnsw/hnsw.hpp
+++ b/include/rabitqlib/index/hnsw/hnsw.hpp
@@ -423,7 +423,7 @@ inline HierarchicalNSW::HierarchicalNSW(
         offsetExData_ + size_ex_data_;  // (# of edges + edges) + (cluster_id) + (external
                                         // label) + (BinData) + (ExData)
     data_level0_memory_ =
-        reinterpret_cast<char*>(malloc(max_elements_ * size_data_per_element_));
+        memory::huge_page_allocate<char>(max_elements_ * size_data_per_element_);
     if (data_level0_memory_ == nullptr) {
         throw std::runtime_error("Not enough memory");
     }
@@ -549,7 +549,7 @@ inline void HierarchicalNSW::load(const char* filename) {
     input.read(reinterpret_cast<char*>(&ef_construction_), sizeof(size_t));
 
     const size_t centroids_bytes = num_cluster_ * padded_dim_ * sizeof(float);
-    centroids_memory_ = reinterpret_cast<char*>(malloc(centroids_bytes));
+    centroids_memory_ = memory::huge_page_allocate<char>(centroids_bytes);
     if (centroids_memory_ == nullptr) {
         throw std::runtime_error("Not enough memory: loadIndex failed to allocate centroids"
         );
@@ -561,7 +561,7 @@ inline void HierarchicalNSW::load(const char* filename) {
     );
 
     data_level0_memory_ =
-        reinterpret_cast<char*>(malloc(max_elements_ * size_data_per_element_));
+        memory::huge_page_allocate<char>(max_elements_ * size_data_per_element_);
 
     input.read(
         data_level0_memory_,

--- a/include/rabitqlib/utils/memory.hpp
+++ b/include/rabitqlib/utils/memory.hpp
@@ -86,6 +86,14 @@ inline T* align_allocate(size_t nbytes) {
     return static_cast<T*>(ptr);
 }
 
+inline constexpr size_t kHugePageSize = 2UL << 20;
+
+// Allocate a large buffer backed by transparent huge pages.
+template <typename T>
+inline T* huge_page_allocate(size_t nbytes) {
+    return align_allocate<kHugePageSize, T, true>(nbytes);
+}
+
 static inline void prefetch_l1(const void* addr) {
 #if defined(__SSE2__)
     _mm_prefetch(addr, _MM_HINT_T0);


### PR DESCRIPTION
This PR enables hugepage if the device setting is set to madvise mode. The groundwork was already there in the library. 

`data_level0_memory_` is ~1.28 GiB and every candidate visit is a random access into it. With THP in `madvise` mode a plain `malloc` gets **no** huge pages, so that array sits on ~335,000 4 KiB pages against a ~2048-entry STLB — nearly every visit misses and takes a page walk.  The hugepage size is set to 2MB.

The gain exists because this host is in `madvise` mode. On a host set to `always` it is already there without the patch; on `never`, `MADV_HUGEPAGE` is ignored and it fallbacks to original behaviour.
## Benchmarks

dataset: GIST1M, topk = 10
EF | Original QPS | Hugepage QPS | Recall | Gain (%)
-- | -- | -- | -- | --
60 | 7,903.70 | 8,608.78 | 0.8075 | 8.92%
150 | 3,786.11 | 4,198.25 | 0.9080 | 10.89%
300 | 2,024.44 | 2,127.25 | 0.9532 | 5.08%
500 | 1,274.77 | 1,327.83 | 0.9677 | 4.16%
1000 | 624.46 | 670.49 | 0.9787 | 7.37%
2000 | 313.69 | 327.43 | 0.9825 | 4.38%
