### PR TITLE
ci: check out repository before creating release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download wheel artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- check out the tagged repository before invoking `gh release create --verify-tag`
- keep tag verification enabled for future automated releases

## Context

The v0.2.0 wheels and PyPI publication succeeded, but the GitHub Release job failed because it ran outside a Git working tree. The v0.2.0 GitHub Release was completed manually with the same six verified workflow artifacts.