### PR TITLE
ci: support Python 3.11 through 3.14

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.11", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,16 @@ jobs:
               )
           PY
 
-      - name: Build and test wheels
+      - name: Build and test PR wheel
+        if: github.event_name == 'pull_request'
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          CIBW_BUILD: cp311-manylinux_x86_64
+        with:
+          output-dir: wheelhouse
+
+      - name: Build and test release wheels
+        if: github.event_name != 'pull_request'
         uses: pypa/cibuildwheel@v4.2.0
         with:
           output-dir: wheelhouse

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 pip install rabitqlib
 ```
 
-Prebuilt wheels support Linux x86-64 and CPython 3.9–3.14. AVX2 + FMA is the
+Prebuilt wheels support Linux x86-64 and CPython 3.11–3.14. AVX2 + FMA is the
 portable CPU baseline; supported AVX-512 kernels are selected at runtime.
 
 ## Adopted across the vector-search ecosystem

--- a/docs/docs/quick_start.md
+++ b/docs/docs/quick_start.md
@@ -7,7 +7,7 @@ a C++17 API for both indexes and low-level quantization.
 
 - An x86-64 CPU supported by the selected kernels: most paths accept either
   AVX2 with FMA or AVX-512F/BW/DQ with FMA
-- Python 3.9 or newer for the Python package
+- Python 3.11 or newer for the Python package
 - A C++17 compiler with OpenMP support
 - CMake 3.15 or newer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rabitqlib"
 version = "0.2.0"
 description = "RaBitQ Python bindings for HNSW, IVF, and SymQG"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = ["numpy"]
 
 [project.optional-dependencies]
@@ -24,7 +24,7 @@ cmake.args = [
 ]
 
 [tool.cibuildwheel]
-build = "cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64"
+build = "cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64"
 build-verbosity = 1
 environment = { CMAKE_ARGS = "-DRABITQ_ENABLE_NATIVE_OPTIMIZATION=OFF" }
 test-requires = "pytest"
@@ -35,7 +35,7 @@ testpaths = ["tests/python"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]


### PR DESCRIPTION
## Summary

- raise the Python package minimum from 3.9 to 3.11
- publish Linux x86-64 wheels for CPython 3.11 through 3.14
- test the oldest and newest supported Python versions in regular CI
- build one CPython 3.11 smoke-test wheel on pull requests
- continue building all four wheels for tag releases
- update README, documentation, and Ruff's target version

## Verification

- Ruff 0.16.1 formatting and lint checks passed
- built a CPython 3.14 wheel with native optimization disabled
- installed that wheel and ran the Python suite: 58 passed

## Repository setting follow-up

After this PR's checks are available, update main branch protection to stop requiring `Python 3.9` and `Python 3.12`, and require `Python 3.14` instead.