### PR TITLE
release: prepare v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 </p>
 
 <p>
-  <a href="https://pypi.org/project/rabitqlib/"><img alt="PyPI" src="https://img.shields.io/pypi/v/rabitqlib.svg"></a>
-  <a href="https://pypi.org/project/rabitqlib/"><img alt="Python versions" src="https://img.shields.io/pypi/pyversions/rabitqlib.svg"></a>
+  <a href="https://pypi.org/project/rabitqlib/"><img alt="PyPI" src="https://img.shields.io/pypi/v/rabitqlib.svg?cacheSeconds=300"></a>
+  <a href="https://pypi.org/project/rabitqlib/"><img alt="Python versions" src="https://img.shields.io/badge/python-3.11--3.14-3776AB.svg?logo=python&amp;logoColor=white"></a>
   <a href="https://github.com/VectorDB-NTU/RaBitQ-Library/actions/workflows/test.yaml"><img alt="C++ tests" src="https://github.com/VectorDB-NTU/RaBitQ-Library/actions/workflows/test.yaml/badge.svg"></a>
   <a href="https://github.com/VectorDB-NTU/RaBitQ-Library/actions/workflows/python.yml"><img alt="Python tests" src="https://github.com/VectorDB-NTU/RaBitQ-Library/actions/workflows/python.yml/badge.svg"></a>
   <a href="https://vectordb-ntu.github.io/RaBitQ-Library/"><img alt="Documentation" src="https://github.com/VectorDB-NTU/RaBitQ-Library/actions/workflows/docs.yml/badge.svg"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,19 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rabitqlib"
-version = "0.2.0"
+version = "0.2.1"
 description = "RaBitQ Python bindings for HNSW, IVF, and SymQG"
 readme = "README.md"
 requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
 dependencies = ["numpy"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- bump the package version to 0.2.1
- publish Python 3.11 through 3.14 classifiers in wheel metadata
- replace the missing dynamic Python badge with an accurate Python 3.11–3.14 badge
- reduce the PyPI version badge cache duration

## Verification

- Ruff 0.16.1 formatting and lint checks passed
- built and installed `rabitqlib-0.2.1-cp314-cp314-linux_x86_64.whl`
- verified the wheel's Version, Requires-Python, and Classifier metadata
- Python tests: 58 passed