### PR TITLE
metadata: add project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,13 @@ classifiers = [
 ]
 dependencies = ["numpy"]
 
+[project.urls]
+Homepage = "https://vectordb-ntu.github.io/RaBitQ-Library/"
+Documentation = "https://vectordb-ntu.github.io/RaBitQ-Library/"
+Repository = "https://github.com/VectorDB-NTU/RaBitQ-Library"
+Issues = "https://github.com/VectorDB-NTU/RaBitQ-Library/issues"
+Paper = "https://doi.org/10.1145/3725413"
+
 [project.optional-dependencies]
 test = ["pytest>=7", "numpy"]
 


### PR DESCRIPTION
## Summary

Add PEP 621 project URLs for:

- homepage
- documentation
- source repository
- issue tracker
- SIGMOD camera-ready paper

These links will be included in future wheel metadata and shown on PyPI after the next release.

## Verification

- parsed `pyproject.toml` successfully
- built a Python 3.14 wheel
- verified all five `Project-URL` entries in the wheel's embedded `METADATA`