### PR TITLE
Release v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rabitqlib"
-version = "0.2.1"
+version = "0.2.2"
 description = "RaBitQ Python bindings for HNSW, IVF, and SymQG"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump the Python package version from 0.2.1 to 0.2.2

After merge, tag the merge commit as v0.2.2 to trigger the release workflow, publish wheels to PyPI, and create the GitHub release.