### PR TITLE
Release v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rabitqlib"
-version = "0.2.2"
+version = "0.3.0"
 description = "RaBitQ Python bindings for HNSW, IVF, and SymQG"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump the Python package version to 0.3.0
- prepare the QG-quant release

## Verification
- C++ tests: 51 passed
- Python tests: 61 passed
- built and installed the rabitqlib 0.3.0 CPython 3.13 wheel locally